### PR TITLE
fix tsconfig.json build target es6 not working issue

### DIFF
--- a/src/controllers/controller.ts
+++ b/src/controllers/controller.ts
@@ -94,7 +94,7 @@ export default class Controller {
     private metadataToEndpoints(): Controller {
 
         this.endpoints = <Endpoint[]> Object
-            .keys(this.targetClass.prototype)
+            .getOwnPropertyNames(this.targetClass.prototype)
             .map<Endpoint | boolean>((targetKey: string) => {
 
                 if (!Metadata.has(ENDPOINT_ARGS, this.targetClass, targetKey)) {


### PR DESCRIPTION
Thanks for the great project. It helps a lot.

I found an issue when I use tsc compiler compile to target es6, the controller doesn't work.
So I dig in the source code, I found that when compile to es6, the controller class doesn't convert to function style, then the `Object.keys(this.targetClass.prototype)` always return blank array `[]`.

for example
```
// compiler target es6 
class UsersController { 

  constructor(templateService, calendarsServer) {
    this.templateService = templateService;
    this.calendarsServer = calendarsServer;
  }

  indexAction(request, response) {
  }

  get index() {
  }

};

// compiler target es5
function UsersController1(templateService, calendarsServer) {
    this.templateService = templateService;
    this.calendarsServer = calendarsServer;
}

UsersController1.prototype.indexAction = function(request, response) {
}

const p1 = UsersController.prototype;
const p2 = UsersController1.prototype;

console.log(p1);
console.log(p2);

console.log(Object.keys(p1).length); // returns 0
console.log(Object.keys(p2).length); // returns 1
```

I made a PR to fix this using `Object.getOwnPropertyNames` refer to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties

Thanks,
Vincent

