### PR TITLE
Proposal for autorisation config

### DIFF
--- a/src/decorators/authenticated.ts
+++ b/src/decorators/authenticated.ts
@@ -2,11 +2,11 @@
 import {Use} from "./use";
 import * as Express from "express";
 
-export function Authenticated(): Function {
+export function Authenticated(autorisation?): Function {
     return Use((request, response, next: Express.NextFunction): void => {
         /* istanbul ignore else */
         if (typeof request.$tryAuth === "function") {
-            request.$tryAuth(request, response, next);
+            request.$tryAuth(request, response, next, autorisation);
         }
     });
 }

--- a/src/interfaces/Express.d.ts
+++ b/src/interfaces/Express.d.ts
@@ -9,7 +9,7 @@ declare namespace Express {
     }
 
     interface Request {
-        $tryAuth: (request: core.Request, response: core.Response, next: Express.NextFunction) => boolean;
+        $tryAuth: (request: core.Request, response: core.Response, next: Express.NextFunction, autorisation?) => boolean;
     }
 }
 

--- a/test/helper/controllers/calendars/CalendarCtrl.ts
+++ b/test/helper/controllers/calendars/CalendarCtrl.ts
@@ -201,7 +201,7 @@ export class CalendarCtrl {
 
 
     @Delete("/")
-    @Authenticated()
+    @Authenticated({role: "admin"})
     public remove(
         @BodyParams("id") @Required() id: string
     ): any {


### PR DESCRIPTION
This would enable autorisation based on a autorisation config object passed in `@Autentication()` decorator.

Example `@Authenticated({role: "admin"})`