### PR TITLE
[Decorator] Add table and model related decorators

### DIFF
--- a/src/constants/metadata-keys.ts
+++ b/src/constants/metadata-keys.ts
@@ -1,33 +1,37 @@
 // controllers
-export const CONTROLLER_URL = "tsed:controller:url";
-export const CONTROLLER_DEPEDENCIES = "ted:controller:depedencies";
-export const CONTROLLER_MOUNT_ENDPOINTS = "ted:controller:endpoints";
-export const ENDPOINT_ARGS = "tsed:endpoint";
-export const ENDPOINT_VIEW = "tsed:endpoint:view";
-export const ENDPOINT_VIEW_OPTIONS = "tsed:endpoint:view-options";
+export const CONTROLLER_URL             = "tsed:controller:url";
+export const CONTROLLER_DEPEDENCIES     = "tsed:controller:dependencies";
+export const CONTROLLER_MOUNT_ENDPOINTS = "tsed:controller:endpoints";
+export const ENDPOINT_ARGS              = "tsed:endpoint";
+export const ENDPOINT_VIEW              = "tsed:endpoint:view";
+export const ENDPOINT_VIEW_OPTIONS      = "tsed:endpoint:view-options";
 
 // converters
-export const CONVERTER = "tsed:converter";
-export const JSON_METADATA = "tsed:json:property";
-export const JSON_PROPERTIES = "tsed:json:properties";
+export const CONVERTER                  = "tsed:converter";
+export const JSON_METADATA              = "tsed:json:property";
+export const JSON_PROPERTIES            = "tsed:json:properties";
+
+// models
+export const TABLE                      = "tsed:table";
+export const COLUMN                     = "tsed:column";
 
 // INJECTION META TO CONTROLLER METHOD
-export const INJECT_PARAMS = "tsed:inject:params";
+export const INJECT_PARAMS              = "tsed:inject:params";
 
 // used to access design time types
-export const DESIGN_PARAM_TYPES = "design:paramtypes";
-export const DESIGN_TYPE = "design:type";
+export const DESIGN_PARAM_TYPES         = "design:paramtypes";
+export const DESIGN_TYPE                = "design:type";
 
-export const SERVICE = "tsed:service:type";
-export const SERVICE_INSTANCE = "tsed:service:instance";
+export const SERVICE                    = "tsed:service:type";
+export const SERVICE_INSTANCE           = "tsed:service:instance";
 
 // SYMBOLS
-export const EXPRESS_NEXT_FN = Symbol("next");
-export const EXPRESS_REQUEST = Symbol("request");
-export const EXPRESS_RESPONSE = Symbol("response");
-export const GET_HEADER = Symbol("getHeader");
-export const PARSE_COOKIES = Symbol("parseCookies");
-export const PARSE_BODY = Symbol("parseBody");
-export const PARSE_QUERY = Symbol("parseQuery");
-export const PARSE_PARAMS = Symbol("parseParams");
-export const PARSE_SESSION = Symbol("parseSession");
+export const EXPRESS_NEXT_FN            = Symbol("next");
+export const EXPRESS_REQUEST            = Symbol("request");
+export const EXPRESS_RESPONSE           = Symbol("response");
+export const GET_HEADER                 = Symbol("getHeader");
+export const PARSE_COOKIES              = Symbol("parseCookies");
+export const PARSE_BODY                 = Symbol("parseBody");
+export const PARSE_QUERY                = Symbol("parseQuery");
+export const PARSE_PARAMS               = Symbol("parseParams");
+export const PARSE_SESSION              = Symbol("parseSession");

--- a/src/decorators/controller.ts
+++ b/src/decorators/controller.ts
@@ -1,7 +1,4 @@
-
-import * as ERRORS_MSGS from "../constants/errors-msgs";
-import {getClassName} from "../utils/class";
-import {CONTROLLER_URL, CONTROLLER_DEPEDENCIES, CONTROLLER_MOUNT_ENDPOINTS} from "../constants/metadata-keys";
+import {CONTROLLER_URL, CONTROLLER_DEPEDENCIES} from "../constants/metadata-keys";
 import Metadata from "../metadata/metadata";
 
 export function Controller(ctrlUrl: string, ...ctlrDepedencies: any[]): Function {

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -13,3 +13,4 @@ export * from "./service";
 export * from "./response-view";
 export * from "./converter";
 export * from "./json-property";
+export * from "./model";

--- a/src/decorators/model.ts
+++ b/src/decorators/model.ts
@@ -14,19 +14,19 @@ export function Column(columnName?: string): Function {
 
     return <T> (target: Function, targetKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> => {
 
-        let columns: any;
+        let mappings: any;
 
         const klass = target.constructor;
 
         if (Metadata.has(COLUMN, klass)) {
-            columns = Metadata.get(COLUMN, klass);
+            mappings = Metadata.get(COLUMN, klass);
         } else {
-            columns = {};
+            mappings = {};
         }
 
-        columns[targetKey] = columnName ? columnName : targetKey;
+        mappings[targetKey] = columnName ? columnName : targetKey;
 
-        Metadata.set(COLUMN, columns, klass);
+        Metadata.set(COLUMN, mappings, klass);
 
         return descriptor;
     };

--- a/src/decorators/model.ts
+++ b/src/decorators/model.ts
@@ -1,0 +1,33 @@
+import Metadata from "../metadata/metadata";
+import {TABLE, COLUMN} from "../constants/metadata-keys";
+
+export function Table(tableName: string) {
+
+    return (target: any): void => {
+        if (!Metadata.has(TABLE, target)) {
+            Metadata.set(TABLE, tableName, target);
+        }
+    };
+}
+
+export function Column(columnName?: string): Function {
+
+    return <T> (target: Function, targetKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> => {
+
+        let columns: any;
+
+        const klass = target.constructor;
+
+        if (Metadata.has(COLUMN, klass)) {
+            columns = Metadata.get(COLUMN, klass);
+        } else {
+            columns = {};
+        }
+
+        columns[targetKey] = columnName ? columnName : targetKey;
+
+        Metadata.set(COLUMN, columns, klass);
+
+        return descriptor;
+    };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from "./converters";
 export * from "./server/server-loader";
 export * from "./interfaces/Promise";
 export * from "./interfaces/Crud";
+export * from "./models/model";

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -11,7 +11,11 @@ export class Model {
 
         return Object
             .getOwnPropertyNames(this.mappings())
-            .map(name => `${this.table()}.${this.mappings()[name]} AS '${this.table()}.${name}'`);
+            .map(name => `${this.table()}.${this.mappings()[name]} AS '${this.column(name)}'`);
+    }
+
+    static column(property: string): string {
+        return `${this.table()}.${property}`;
     }
 
     static mappings(): any {

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -9,8 +9,22 @@ export abstract class Model {
 
     static columns(): string[] {
 
-        const columns = Metadata.get(COLUMN, this);
-        return Object.getOwnPropertyNames(columns).map(name => `${this.table()}.${columns[name]}`);
+        return Object
+            .getOwnPropertyNames(this.mappings())
+            .map(name => `${this.table()}.${this.mappings()[name]}`);
+    }
+
+    static mappings(): any {
+
+        return Metadata.get(COLUMN, this);
+    }
+
+    static mappingsReverse(): any {
+
+        return Object.getOwnPropertyNames(this.mappings()).reduce((ret: any, key: string) => {
+            ret[this.mappings()[key]] = key;
+            return ret;
+        }, {});
     }
 
 }

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -7,47 +7,101 @@ export class Model {
         return Metadata.get(TABLE, this);
     }
 
-    static columns(): string[] {
+    static columns(options?: any): string[] {
+
+        const defaultOptions = {
+            prefix: false
+        };
+
+        const _options = Object.assign({}, defaultOptions, options);
 
         return Object
             .getOwnPropertyNames(this.mappings())
-            .map(name => `${this.table()}.${this.mappings()[name]} AS '${this.column(name)}'`);
+            .map(name => `${this.table()}.${this.mappings()[name]} AS '${this.column(name, _options)}'`);
     }
 
-    static column(property: string): string {
-        return `${this.table()}.${property}`;
+    static column(property: string, options?: any): string {
+
+        const defaultOptions = {
+            prefix: false
+        };
+
+        const _options = Object.assign({}, defaultOptions, options);
+
+        const columnName = this.mappings()[property];
+
+        if (typeof columnName !== 'undefined') {
+
+            if (_options.prefix) {
+                return `${this.table()}.${columnName}`;
+            }
+
+            return columnName;
+        }
     }
 
+    static fromDB<T extends Model>(data: any, options?: any): T {
+
+        const defaultOptions = {
+            prefix: false
+        };
+
+        const _options = Object.assign({}, defaultOptions, options);
+
+        const instance = <T>new this();
+
+        for (let column in data) {
+
+            if (data.hasOwnProperty(column)) {
+
+                const value = data[column];
+
+                let key: string;
+
+                if (_options.prefix) {
+
+                    key = column.split(`${this.table()}.`)[1];
+
+                } else {
+
+                    key = column;
+                }
+
+                if (typeof key !== 'undefined') {
+
+                    const property = this.mappingsReverse()[key];
+
+                    if (typeof property !== 'undefined') {
+                        instance[property] = value;
+                    }
+                }
+
+            }
+
+        }
+
+        return instance;
+    }
+
+    /*
+     * @returns
+     *   "Class property" => "DB column"
+     */
     static mappings(): any {
 
         return Metadata.get(COLUMN, this);
     }
 
+    /*
+     * @returns
+     *   "DB column" => "Class property"
+     */
     static mappingsReverse(): any {
 
         return Object.getOwnPropertyNames(this.mappings()).reduce((ret: any, key: string) => {
             ret[this.mappings()[key]] = key;
             return ret;
         }, {});
-    }
-
-    static fromDB(data: any): Model {
-        const instance = new this();
-        for (let property in data) {
-            if (data.hasOwnProperty(property)) {
-
-                const value = data[property];
-                const key = property.split(`${this.table()}.`)[1];
-
-                if (typeof key !== 'undefined') {
-                    console.log(key);
-                    instance[key] = value;
-                }
-
-            }
-        }
-
-        return instance;
     }
 
 }

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -11,7 +11,7 @@ export class Model {
 
         return Object
             .getOwnPropertyNames(this.mappings())
-            .map(name => `${this.table()}.${this.mappings()[name]}`);
+            .map(name => `${this.table()}.${this.mappings()[name]} AS '${this.table()}.${name}'`);
     }
 
     static mappings(): any {
@@ -31,9 +31,15 @@ export class Model {
         const instance = new this();
         for (let property in data) {
             if (data.hasOwnProperty(property)) {
+
                 const value = data[property];
-                const key = this.mappingsReverse()[property];
-                instance[key] = value;
+                const key = property.split(`${this.table()}.`)[1];
+
+                if (typeof key !== 'undefined') {
+                    console.log(key);
+                    instance[key] = value;
+                }
+
             }
         }
 

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,0 +1,16 @@
+import Metadata from "../metadata/metadata";
+import {TABLE, COLUMN} from "../constants/metadata-keys";
+
+export abstract class Model {
+
+    static table(): string {
+        return Metadata.get(TABLE, this);
+    }
+
+    static columns(): string[] {
+
+        const columns = Metadata.get(COLUMN, this);
+        return Object.getOwnPropertyNames(columns).map(name => `${this.table()}.${columns[name]}`);
+    }
+
+}

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -17,7 +17,7 @@ export class Model {
 
         return Object
             .getOwnPropertyNames(this.mappings())
-            .map(name => `${this.table()}.${this.mappings()[name]} AS '${this.column(name, _options)}'`);
+            .map(name => `${this.table()}.${this.mappings()[name]} AS ${this.column(name, _options)}`);
     }
 
     static column(property: string, options?: any): string {

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,7 +1,7 @@
 import Metadata from "../metadata/metadata";
 import {TABLE, COLUMN} from "../constants/metadata-keys";
 
-export abstract class Model {
+export class Model {
 
     static table(): string {
         return Metadata.get(TABLE, this);
@@ -25,6 +25,19 @@ export abstract class Model {
             ret[this.mappings()[key]] = key;
             return ret;
         }, {});
+    }
+
+    static fromDB(data: any): Model {
+        const instance = new this();
+        for (let property in data) {
+            if (data.hasOwnProperty(property)) {
+                const value = data[property];
+                const key = this.mappingsReverse()[property];
+                instance[key] = value;
+            }
+        }
+
+        return instance;
     }
 
 }

--- a/test/helper/models/Event.ts
+++ b/test/helper/models/Event.ts
@@ -1,6 +1,6 @@
-
-
 import {JsonProperty} from '../../../src/decorators/json-property';
+import {Model} from "../../../src/models/model";
+import {Table, Column} from "../../../src/decorators/model";
 
 export class EventModel {
 
@@ -21,4 +21,14 @@ export class EventModel {
 export class Task {
     public name: string = void 0;
     public percent: number;
+}
+
+@Table("comments")
+export class Comment extends Model {
+
+    @Column()
+    private id: number;
+
+    @Column("_content")
+    private content: string
 }

--- a/test/helper/models/Event.ts
+++ b/test/helper/models/Event.ts
@@ -30,5 +30,7 @@ export class Comment extends Model {
     private id: number;
 
     @Column("_content")
-    private content: string
+    private content: string;
+
+    private otherThing: number;
 }

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -5,30 +5,71 @@ const expect: Chai.ExpectStatic = Chai.expect;
 
 describe('Table/Column decorators and Model class: ', () => {
 
-    it('Comment should have table() static method', () => {
-        expect(Comment.table()).to.equal("comments");
+    describe('table() static method', () => {
+
+        it('should return table name', () => {
+            expect(Comment.table()).to.equal('comments');
+        })
+
     });
 
-    it('Comment should have mappings() static method', () => {
-        expect(Comment.mappings()).to.deep.equal({id: 'id', content: '_content'});
+    describe('mappings() static method', () => {
+
+        it('should return mappings', () => {
+            expect(Comment.mappings()).to.deep.equal({id: 'id', content: '_content'});
+        });
+
     });
 
-    it('Comment should have mappingsReverse() static method', () => {
-        expect(Comment.mappingsReverse()).to.deep.equal({id: 'id', _content: 'content'});
+    describe("mappingsReverse() static method", () => {
+
+        it('should return reversed mappings', () => {
+            expect(Comment.mappingsReverse()).to.deep.equal({id: 'id', _content: 'content'});
+        });
+
     });
 
-    it('Comment should have columns() static method', () => {
-        expect(Comment.columns()).to.deep.equal(["comments.id AS 'comments.id'", "comments._content AS 'comments.content'"]);
+    describe('columns() static method', () => {
+
+        it('should return columns without prefix', () => {
+            expect(Comment.columns()).to.deep.equal(["comments.id AS 'id'", "comments._content AS '_content'"]);
+        });
+
+        it('should return columns with prefix', () => {
+            expect(Comment.columns({prefix: true})).to.deep.equal(["comments.id AS 'comments.id'", "comments._content AS 'comments._content'"]);
+        });
     });
 
-    it('Comment should have column() static method', () => {
-        expect(Comment.column('content')).to.deep.equal('comments.content');
+
+    describe("column() static method", () => {
+
+        it('should return column name without prefix', () => {
+            expect(Comment.column('content')).to.deep.equal('_content');
+        });
+
+        it('should return column name with prefix', () => {
+            expect(Comment.column('content', {prefix: true})).to.deep.equal('comments._content');
+        });
+
     });
 
+    describe("fromDB() static method", () => {
 
-    it('Comment should have fromDB() static method', () => {
-        const data = {"comments.content": "<h1>Hello world</h1>", "comments.id": 1};
-        expect(Comment.fromDB(data)).to.have.property('content', data['comments.content']);
-        expect(Comment.fromDB(data)).to.have.property('id', data['comments.id']);
+        it('should handle without prefix data and return instance', () => {
+
+            const data = {_content: "<h1>Hello world</h1>", id: 1};
+            expect(Comment.fromDB(data)).to.have.property('content', data._content);
+            expect(Comment.fromDB(data)).to.have.property('id', data.id);
+
+        });
+
+        it('should return column name with prefix', () => {
+
+            const data = {"comments._content": "<h1>Hello world</h1>", "comments.id": 1};
+            expect(Comment.fromDB(data, {prefix: true})).to.have.property('content', data['comments._content']);
+            expect(Comment.fromDB(data, {prefix: true})).to.have.property('id', data['comments.id']);
+
+        });
+
     });
 });

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -18,12 +18,12 @@ describe('Table/Column decorators and Model class: ', () => {
     });
 
     it('Comment should have columns() static method', () => {
-        expect(Comment.columns()).to.deep.equal(['comments.id', 'comments._content']);
+        expect(Comment.columns()).to.deep.equal(["comments.id AS 'comments.id'", "comments._content AS 'comments.content'"]);
     });
 
     it('Comment should have fromDB() static method', () => {
-        const data = {_content: "<h1>Helle world</h1>", id: 1};
-        expect(Comment.fromDB(data)).to.have.property('content', data._content);
-        expect(Comment.fromDB(data)).to.have.property('id', data.id);
+        const data = {"comments.content": "<h1>Hello world</h1>", "comments.id": 1};
+        expect(Comment.fromDB(data)).to.have.property('content', data['comments.content']);
+        expect(Comment.fromDB(data)).to.have.property('id', data['comments.id']);
     });
 });

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -3,7 +3,7 @@ import {Comment} from './helper/models/Event';
 
 const expect: Chai.ExpectStatic = Chai.expect;
 
-describe('Table/Column decorators and Model abstract class: ', () => {
+describe('Table/Column decorators and Model class: ', () => {
 
     it('Comment should have table() static method', () => {
         expect(Comment.table()).to.equal("comments");
@@ -19,5 +19,11 @@ describe('Table/Column decorators and Model abstract class: ', () => {
 
     it('Comment should have columns() static method', () => {
         expect(Comment.columns()).to.deep.equal(['comments.id', 'comments._content']);
+    });
+
+    it('Comment should have fromDB() static method', () => {
+        const data = {_content: "<h1>Helle world</h1>", id: 1};
+        expect(Comment.fromDB(data)).to.have.property('content', data._content);
+        expect(Comment.fromDB(data)).to.have.property('id', data.id);
     });
 });

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -21,6 +21,11 @@ describe('Table/Column decorators and Model class: ', () => {
         expect(Comment.columns()).to.deep.equal(["comments.id AS 'comments.id'", "comments._content AS 'comments.content'"]);
     });
 
+    it('Comment should have column() static method', () => {
+        expect(Comment.column('content')).to.deep.equal('comments.content');
+    });
+
+
     it('Comment should have fromDB() static method', () => {
         const data = {"comments.content": "<h1>Hello world</h1>", "comments.id": 1};
         expect(Comment.fromDB(data)).to.have.property('content', data['comments.content']);

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -34,11 +34,11 @@ describe('Table/Column decorators and Model class: ', () => {
     describe('columns() static method', () => {
 
         it('should return columns without prefix', () => {
-            expect(Comment.columns()).to.deep.equal(["comments.id AS 'id'", "comments._content AS '_content'"]);
+            expect(Comment.columns()).to.deep.equal(["comments.id AS id", "comments._content AS _content"]);
         });
 
         it('should return columns with prefix', () => {
-            expect(Comment.columns({prefix: true})).to.deep.equal(["comments.id AS 'comments.id'", "comments._content AS 'comments._content'"]);
+            expect(Comment.columns({prefix: true})).to.deep.equal(["comments.id AS comments.id", "comments._content AS comments._content"]);
         });
     });
 

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -17,6 +17,7 @@ describe('Table/Column decorators and Model class: ', () => {
 
         it('should return mappings', () => {
             expect(Comment.mappings()).to.deep.equal({id: 'id', content: '_content'});
+            expect(Comment.mappings()).to.not.have.property('otherThing');
         });
 
     });
@@ -25,6 +26,7 @@ describe('Table/Column decorators and Model class: ', () => {
 
         it('should return reversed mappings', () => {
             expect(Comment.mappingsReverse()).to.deep.equal({id: 'id', _content: 'content'});
+            expect(Comment.mappings()).to.not.have.property('otherThing');
         });
 
     });
@@ -51,11 +53,18 @@ describe('Table/Column decorators and Model class: ', () => {
             expect(Comment.column('content', {prefix: true})).to.deep.equal('comments._content');
         });
 
+        it('should return null with invalid property', () => {
+            expect(Comment.column('invalid')).to.be.undefined;
+        });
+
+        it('should return null with invalid property and option prefix', () => {
+            expect(Comment.column('invalid', {prefix: true})).to.be.undefined;
+        });
     });
 
     describe("fromDB() static method", () => {
 
-        it('should handle without prefix data and return instance', () => {
+        it('should handle data without prefix and return instance', () => {
 
             const data = {_content: "<h1>Hello world</h1>", id: 1};
             expect(Comment.fromDB(data)).to.have.property('content', data._content);
@@ -63,7 +72,7 @@ describe('Table/Column decorators and Model class: ', () => {
 
         });
 
-        it('should return column name with prefix', () => {
+        it('should handle data with prefix and return instance', () => {
 
             const data = {"comments._content": "<h1>Hello world</h1>", "comments.id": 1};
             expect(Comment.fromDB(data, {prefix: true})).to.have.property('content', data['comments._content']);
@@ -71,5 +80,13 @@ describe('Table/Column decorators and Model class: ', () => {
 
         });
 
+        it('should handle other table data and return that instance', () => {
+
+            const data = {"comments._content": "<h1>Hello world</h1>", "comments.id": 1, "users.other1": 1, "other2": 1};
+            expect(Comment.fromDB(data, {prefix: true})).to.have.property('content', data['comments._content']);
+            expect(Comment.fromDB(data, {prefix: true})).to.have.property('id', data['comments.id']);
+            expect(Comment.fromDB(data, {prefix: true})).to.not.have.property('other1');
+            expect(Comment.fromDB(data, {prefix: true})).to.not.have.property('other2');
+        });
     });
 });

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -1,0 +1,23 @@
+import * as Chai from "chai";
+import {Comment} from './helper/models/Event';
+
+const expect: Chai.ExpectStatic = Chai.expect;
+
+describe('Table/Column decorators and Model abstract class: ', () => {
+
+    it('Comment should have table() static method', () => {
+        expect(Comment.table()).to.equal("comments");
+    });
+
+    it('Comment should have mappings() static method', () => {
+        expect(Comment.mappings()).to.deep.equal({id: 'id', content: '_content'});
+    });
+
+    it('Comment should have mappingsReverse() static method', () => {
+        expect(Comment.mappingsReverse()).to.deep.equal({id: 'id', _content: 'content'});
+    });
+
+    it('Comment should have columns() static method', () => {
+        expect(Comment.columns()).to.deep.equal(['comments.id', 'comments._content']);
+    });
+});


### PR DESCRIPTION
Hi @Romakita ,

I just added two new decorators, one is `@Table`, one is `@Column`.

These two mainly for build db query, the Table will accept one parameter which is the table name in database.

The second one have an optional parameter to which is the column name in the database.

I also add one abstract model, all the application level model should extend this abstract model.
And every application level model have two static methods: `table`, `columns` then.

For example:

```
class Comment extends Model {
    @Column("_id")
    private id: number;
}

Comment.table() # => "comments"
Comment.columns() # => ["comments._id"]
```

So I can build the query with Knex like follows
```
.select(Comment.columns())
.from(Comment.table())
.where(...)
```
