### PR TITLE
Pass bind interface to http server

### DIFF
--- a/src/server/server-loader.ts
+++ b/src/server/server-loader.ts
@@ -261,14 +261,21 @@ export abstract class ServerLoader {
 
         if (this.httpServer) {
 
-            $log.debug("[TSED] Start HTTP server on port : " + this.httpPort);
+            let hostname = "0.0.0.0";
+            let port = this.httpPort;
 
-            this.httpServer.listen(this.httpPort);
+            if (typeof this.httpPort === "string" && this.httpPort.indexOf(":") > -1) {
+                [hostname, port] = this.httpPort.split(":");
+            }
+
+            $log.debug(`[TSED] Start HTTP server on ${hostname}:${port}`);
+            this.httpServer.listen(+port, hostname);
 
             promises.push(new Promise<any>((resolve, reject) => {
                 this._httpServer
                     .on("listening", () => {
-                        $log.info("[TSED] HTTP Server listen port : " + this.httpPort);
+                        let { address, port } = this._httpServer.address();
+                        $log.info(`[TSED] HTTP Server listen on ${address}:${port}`);
                         resolve();
                     })
                     .on("error", reject);
@@ -277,14 +284,21 @@ export abstract class ServerLoader {
 
         if (this.httpsServer) {
 
-            $log.debug("[TSED] Start HTTPs server on port : " + this.httpsPort);
+            let hostname = "0.0.0.0";
+            let port = this.httpPort;
 
+            if (typeof this.httpPort === "string" && this.httpPort.indexOf(":") > -1) {
+                [hostname, port] = this.httpPort.split(":");
+            }
+
+            $log.debug(`[TSED] Start HTTPs server on ${hostname}:${port}`);
             this.httpsServer.listen(this.httpsPort);
 
             promises.push(new Promise<any>((resolve, reject) => {
                 this._httpsServer
                     .on("listening", () => {
-                        $log.info("[TSED] HTTPs Server listen port : " + this.httpsPort);
+                        let { address, port } = this._httpsServer.address();
+                        $log.info(`[TSED] HTTPs Server listen port ${address}:${port}`);
                         resolve();
                     })
                     .on("error", reject);

--- a/src/server/server-loader.ts
+++ b/src/server/server-loader.ts
@@ -261,20 +261,21 @@ export abstract class ServerLoader {
 
         if (this.httpServer) {
 
-            let hostname = "0.0.0.0";
+            let address = "0.0.0.0";
             let port = this.httpPort;
 
             if (typeof this.httpPort === "string" && this.httpPort.indexOf(":") > -1) {
-                [hostname, port] = this.httpPort.split(":");
+                [address, port] = this.httpPort.split(":");
             }
 
-            $log.debug(`[TSED] Start HTTP server on ${hostname}:${port}`);
-            this.httpServer.listen(+port, hostname);
+            $log.debug(`[TSED] Start HTTP server on ${address}:${port}`);
+            this.httpServer.listen(+port, address);
 
             promises.push(new Promise<any>((resolve, reject) => {
                 this._httpServer
                     .on("listening", () => {
-                        let { address, port } = this._httpServer.address();
+                        // The address should be read from server instance but it seems like mocha is failing with this
+                        // let { address, port } = this._httpServer.address();
                         $log.info(`[TSED] HTTP Server listen on ${address}:${port}`);
                         resolve();
                     })
@@ -284,20 +285,21 @@ export abstract class ServerLoader {
 
         if (this.httpsServer) {
 
-            let hostname = "0.0.0.0";
+            let address = "0.0.0.0";
             let port = this.httpPort;
 
             if (typeof this.httpPort === "string" && this.httpPort.indexOf(":") > -1) {
-                [hostname, port] = this.httpPort.split(":");
+                [address, port] = this.httpPort.split(":");
             }
 
-            $log.debug(`[TSED] Start HTTPs server on ${hostname}:${port}`);
+            $log.debug(`[TSED] Start HTTPs server on ${address}:${port}`);
             this.httpsServer.listen(this.httpsPort);
 
             promises.push(new Promise<any>((resolve, reject) => {
                 this._httpsServer
                     .on("listening", () => {
-                        let { address, port } = this._httpsServer.address();
+                        // The address should be read from server instance but it seems like mocha is failing with this
+                        // let { address, port } = this._httpsServer.address();
                         $log.info(`[TSED] HTTPs Server listen port ${address}:${port}`);
                         resolve();
                     })


### PR DESCRIPTION
Allow create server on specific interface ex: `server.createHttpServer('127.0.0.1:49080')`

Http.listen is not expanding by default `hostname:port`. It has a first parameter string but is the path for a local socket connection. If we want to pass a local interface we should call `Http.listen(port, interface)`