### PR TITLE
Do not send data if headers already sent

### DIFF
--- a/src/controllers/endpoint.ts
+++ b/src/controllers/endpoint.ts
@@ -254,6 +254,10 @@ export class Endpoint {
         const viewPath = Metadata.get(ENDPOINT_VIEW, instance, this.methodClassName);
         const viewOptions = Metadata.get(ENDPOINT_VIEW_OPTIONS, instance, this.methodClassName);
 
+        if (response.headersSent) {
+            return data;
+        }
+
         if (viewPath !== undefined) {
 
             if (viewOptions !== undefined ) {


### PR DESCRIPTION
Let the user send data "by hand". If headers are already send probably
the user used `response.send(data)`. We should not try to send it or we
will get a 'Headers already sent' error.