### PR TITLE
feat(swagger): Add method to generate docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "homepage": "https://github.com/romakita/ts-express-decorators#readme",
   "dependencies": {
+    "@types/swagger-schema-official": "^2.0.5",
     "colors": "^1.1.2",
     "glob": "^7.0.3",
     "reflect-metadata": "^0.1.8",

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
   },
   "homepage": "https://github.com/romakita/ts-express-decorators#readme",
   "dependencies": {
-    "@types/swagger-schema-official": "^2.0.5",
     "colors": "^1.1.2",
     "glob": "^7.0.3",
     "reflect-metadata": "^0.1.8",
     "source-map-support": "^0.4.0",
     "ts-httpexceptions": "^2.1.1",
-    "ts-log-debug": "^2.2.0"
+    "ts-log-debug": "^2.2.0",
+    "swagger-schema-official": "^2.0.0-bab6bed"
   },
   "devDependencies": {
     "@types/chai": "^3.4.32",
@@ -56,6 +56,7 @@
     "@types/node": "^7.0.0",
     "@types/superagent": "^2.0.34",
     "@types/supertest": "^2.0.0",
+    "@types/swagger-schema-official": "^2.0.5",
     "body-parser": "^1.15.1",
     "chai": "^3.5.0",
     "compression": "^1.6.1",
@@ -71,6 +72,7 @@
     "remap-istanbul": "^0.9.1",
     "rimraf": "^2.6.1",
     "supertest": "^3.0.0",
+    "swagger-ui-express": "^2.0.0",
     "tslint": "^4.4.2",
     "typescript": "^2.0.2"
   },

--- a/src/constants/metadata-keys.ts
+++ b/src/constants/metadata-keys.ts
@@ -10,6 +10,7 @@ export const CONTROLLER_MOUNT_ENDPOINTS = "ted:controller:endpoints";
 export const ENDPOINT_USE = "tsed:endpoint:use";
 export const ENDPOINT_USE_BEFORE = "tsed:endpoint:use:before";
 export const ENDPOINT_USE_AFTER = "tsed:endpoint:use:after";
+export const ENDPOINT_API_INFO = "tsed:endpoint:api:info";
 
 // converters
 export const CONVERTER = "tsed:converter";
@@ -22,7 +23,6 @@ export const INJECT_PARAMS = "tsed:inject:params";
 export const DESIGN_PARAM_TYPES = "design:paramtypes";
 export const DESIGN_TYPE = "design:type";
 export const DESIGN_RETURN_TYPE = "design:returntype";
-export const DESIGN_RETURN_CONTENT_TYPE = "design:return:content-type";
 
 // SYMBOLS
 export const EXPRESS_NEXT_FN = Symbol("next");

--- a/src/constants/metadata-keys.ts
+++ b/src/constants/metadata-keys.ts
@@ -22,6 +22,7 @@ export const INJECT_PARAMS = "tsed:inject:params";
 export const DESIGN_PARAM_TYPES = "design:paramtypes";
 export const DESIGN_TYPE = "design:type";
 export const DESIGN_RETURN_TYPE = "design:returntype";
+export const DESIGN_RETURN_CONTENT_TYPE = "design:return:content-type";
 
 // SYMBOLS
 export const EXPRESS_NEXT_FN = Symbol("next");

--- a/src/controllers/endpoint.ts
+++ b/src/controllers/endpoint.ts
@@ -1,4 +1,4 @@
-import {ENDPOINT_USE, ENDPOINT_USE_AFTER, ENDPOINT_USE_BEFORE} from "../constants/metadata-keys";
+import {ENDPOINT_API_INFO, ENDPOINT_USE, ENDPOINT_USE_AFTER, ENDPOINT_USE_BEFORE} from "../constants/metadata-keys";
 import Metadata from "../services/metadata";
 import {InjectorService} from "../services";
 import MiddlewareService from "../services/middleware";
@@ -262,6 +262,9 @@ export class Endpoint {
      */
     public getMetadata = (key: any) => Metadata.get(typeof key === "string" ? key : getClassName(key), this.targetClass, this.methodClassName);
 
+    public getApiInfo() {
+        return Metadata.getApiInfo(this.targetClass, this.methodClassName);
+    }
     /**
      * Store value for an endpoint method.
      * @param key
@@ -271,6 +274,15 @@ export class Endpoint {
      */
     static setMetadata = (key: any, value: any, targetClass: any, methodClassName: any) => Metadata.set(typeof key === "string" ? key : getClassName(key), value, targetClass, methodClassName);
 
+    static setApiInfo(value: { [key: string]: any }, targetClass: any, methodClassName: any) {
+        this.setMetadata(ENDPOINT_API_INFO, value, targetClass, methodClassName);
+        return this;
+    }
+
+    static getApiInfo(targetClass: any, methodClassName: any) {
+        return this.getMetadata(ENDPOINT_API_INFO, targetClass, methodClassName) || {};
+    }
+
     /**
      * Return the stored value for an endpoint method.
      * @param key
@@ -278,5 +290,4 @@ export class Endpoint {
      * @param methodClassName
      */
     static getMetadata = (key: any, targetClass: any, methodClassName: any) => Metadata.get(typeof key === "string" ? key : getClassName(key), targetClass, methodClassName);
-
 }

--- a/src/controllers/endpoint.ts
+++ b/src/controllers/endpoint.ts
@@ -263,7 +263,7 @@ export class Endpoint {
     public getMetadata = (key: any) => Metadata.get(typeof key === "string" ? key : getClassName(key), this.targetClass, this.methodClassName);
 
     public getApiInfo() {
-        return Metadata.getApiInfo(this.targetClass, this.methodClassName);
+        return Endpoint.getApiInfo(this.targetClass, this.methodClassName);
     }
     /**
      * Store value for an endpoint method.

--- a/src/decorators/authenticated.ts
+++ b/src/decorators/authenticated.ts
@@ -1,4 +1,3 @@
-
 import {UseBefore} from "./use-before";
 import {Endpoint} from "../controllers/endpoint";
 import AuthenticatedMiddleware from "../middlewares/authenticated";
@@ -19,12 +18,21 @@ import AuthenticatedMiddleware from "../middlewares/authenticated";
  * @returns {Function}
  * @constructor
  */
-export function Authenticated(options?: any): Function {
+export function Authenticated(options: any = {}): Function {
 
 
-    return <T> (target: Function, targetKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> => {
+    return <T>(target: Function, targetKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> => {
 
         Endpoint.setMetadata(AuthenticatedMiddleware, options, target, targetKey);
+        const apiInfo = Endpoint.getApiInfo(target, targetKey);
+
+        apiInfo.responses = (apiInfo.response || []).push({
+            status: 403,
+            description: options.description || "Forbidden",
+            options
+        });
+
+        Endpoint.setApiInfo(apiInfo, target, targetKey);
 
         return UseBefore(AuthenticatedMiddleware)(target, targetKey, descriptor);
     };

--- a/src/decorators/content-type.ts
+++ b/src/decorators/content-type.ts
@@ -1,4 +1,6 @@
 import {UseAfter} from "./use-after";
+import {Endpoint} from "../controllers/endpoint";
+import {DESIGN_RETURN_CONTENT_TYPE} from "../constants/metadata-keys";
 /**
  * Sets the Content-Type HTTP header to the MIME type as determined by mime.lookup() for the specified type.
  * If type contains the “/” character, then it sets the `Content-Type` to type.
@@ -19,6 +21,8 @@ import {UseAfter} from "./use-after";
 export function ContentType(type: string): Function {
 
     return <T> (target: Function, targetKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> => {
+
+        Endpoint.setMetadata(DESIGN_RETURN_CONTENT_TYPE, type, target, targetKey);
 
         return UseAfter((request, response, next) => {
 

--- a/src/decorators/content-type.ts
+++ b/src/decorators/content-type.ts
@@ -20,9 +20,14 @@ import {DESIGN_RETURN_CONTENT_TYPE} from "../constants/metadata-keys";
  */
 export function ContentType(type: string): Function {
 
-    return <T> (target: Function, targetKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> => {
+    return <T>(target: Function, targetKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> => {
 
-        Endpoint.setMetadata(DESIGN_RETURN_CONTENT_TYPE, type, target, targetKey);
+        const apiInfo = Endpoint.getApiInfo(target, targetKey);
+
+        apiInfo.produces = apiInfo.produces || [];
+        apiInfo.produces.push(type);
+
+        Endpoint.setApiInfo(apiInfo, target, targetKey);
 
         return UseAfter((request, response, next) => {
 

--- a/src/decorators/content-type.ts
+++ b/src/decorators/content-type.ts
@@ -1,6 +1,5 @@
 import {UseAfter} from "./use-after";
 import {Endpoint} from "../controllers/endpoint";
-import {DESIGN_RETURN_CONTENT_TYPE} from "../constants/metadata-keys";
 /**
  * Sets the Content-Type HTTP header to the MIME type as determined by mime.lookup() for the specified type.
  * If type contains the “/” character, then it sets the `Content-Type` to type.

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -15,6 +15,7 @@ export * from "./deprecated";
 // Parameters
 export * from "./response-data";
 export * from "./authenticated";
+export * from "./content-type";
 export * from "./required";
 export * from "./params";
 export * from "./response";

--- a/src/server/server-loader.ts
+++ b/src/server/server-loader.ts
@@ -12,6 +12,7 @@ import {
     IServerMountDirectories, IServerSettings, ServerSettingsProvider, ServerSettingsService
 } from "../services/server-settings";
 import GlobalErrorHandlerMiddleware from "../middlewares/global-error-handler";
+import SwaggerService from "../services/swagger";
 
 export interface IHTTPSServerOptions extends Https.ServerOptions {
     port: string | number;
@@ -197,9 +198,11 @@ export abstract class ServerLoader implements IServerLifecycle {
             .then(() => {
 
                 const controllerService = this.injectorService.get<ControllerService>(ControllerService);
+                const swaggerService = this.injectorService.get<SwaggerService>(SwaggerService);
 
                 $log.info("[TSED] Import controllers");
                 controllerService.load();
+                swaggerService.load();
 
                 $log.info("[TSED] Routes mounted :");
                 controllerService.printRoutes($log);

--- a/src/services/controller.ts
+++ b/src/services/controller.ts
@@ -1,7 +1,3 @@
-import {
-    BodyParameter, FormDataParameter, Parameter, Path, PathParameter, QueryParameter, Schema, Spec
-} from "@types/swagger-schema-official";
-
 import {Service} from "../decorators/service";
 import {ExpressApplication} from "./express-application";
 import Controller from "../controllers/controller";
@@ -33,9 +29,7 @@ export default class ControllerService {
      *
      * @param expressApplication
      */
-    constructor (
-        @Inject(ExpressApplication) private expressApplication: ExpressApplication
-    ) {
+    constructor(@Inject(ExpressApplication) private expressApplication: ExpressApplication) {
 
     }
 
@@ -93,6 +87,7 @@ export default class ControllerService {
 
         return this;
     }
+
     /**
      * Map all controllers collected by @Controller annotation.
      */
@@ -284,145 +279,10 @@ export default class ControllerService {
         return routes;
     }
 
-
-    public getOpenAPISpec(): Spec {
-
-        let openAPI: Spec = {
-            "swagger": "2.0",
-            "info": {
-                "version": "1.0.0",
-                "title": "Swagger",
-            },
-            "paths": {}
-        };
-
-        let paths: { [pathName: string]: Path } = {};
-
-
-        const getOpenAPIPath = (expressPath: string | RegExp): string | RegExp => {
-            if (typeof expressPath === "string") {
-                let params = expressPath.match(/:[\w]+/g);
-
-                let OpenAPIPath = expressPath;
-                if (params) {
-                    let swagerParams = params.map(x => {
-                        return "{" + x.replace(":", "") + "}";
-                    });
-
-                    OpenAPIPath = params.reduce((acc, el, ix) => {
-                        return acc.replace(el, swagerParams[ix]);
-                    }, expressPath);
-                }
-                return OpenAPIPath;
-            } else {
-                return expressPath;
-            }
-        };
-
-        const getOpenAPIParams = (tsDecoratorsParams: any): Parameter[] => {
-            let OpenAPIParameters: Parameter[] = [];
-
-            let bodyParams: BodyParameter = {in: "", name: ""};
-
-            let notBodyParams: PathParameter | QueryParameter | FormDataParameter;
-            notBodyParams = {type: "", name: "", required: false, in: ""};
-
-            let hasBodyParams = false;
-            tsDecoratorsParams.forEach(p => {
-                switch (p.name) {
-                    case "parseParams":
-                        notBodyParams.in = "path";
-                        notBodyParams.required = true;
-                        notBodyParams.type = p.use ? p.use.name.toLowerCase() : "";
-                        break;
-                    case "parseBody":
-                        hasBodyParams = true;
-                        if (!bodyParams.schema) {
-                            bodyParams.schema = {};
-                            bodyParams.schema.properties = {};
-                        }
-                        let property: Schema = {
-                            type: p.use ? p.use.name.toLowerCase() : ""
-                        };
-                        bodyParams.schema.properties[p.expression] = property;
-                        if (p.required) {
-                            if (!bodyParams.schema.required) bodyParams.schema.required = [];
-                            bodyParams.schema.required.push(p.expression);
-                        }
-                        break;
-                    default:
-                        notBodyParams["in"] = "path";
-                        notBodyParams["type"] = p.use ? p.use.name.toLowerCase() : "";
-                }
-                notBodyParams.name = p.expression;
-                if (p.name !== "parseBody" && p.expression) {
-                    if (p.required) notBodyParams["required"] = true;
-                    OpenAPIParameters.push(notBodyParams);
-                }
-            });
-
-            if (hasBodyParams) {
-                bodyParams.in = "body";
-                bodyParams.name = "bodyParam";
-                bodyParams.schema.type = "object";
-                OpenAPIParameters.push(bodyParams);
-            }
-            return OpenAPIParameters;
-        };
-
-        const buildRoutes = (ctrl: Controller, endpointUrl: string) => {
-
-            ctrl.dependencies.forEach((ctrl: Controller) => buildRoutes(ctrl, `${endpointUrl}${ctrl.endpointUrl}`));
-
-            ctrl.endpoints.forEach((endpoint: Endpoint) => {
-
-                if (endpoint.hasMethod()) {
-
-                    const className = getClassName(ctrl.targetClass),
-                        parameters = InjectParams.getParams(ctrl.targetClass, endpoint.methodClassName),
-                        returnContentType = Metadata.getReturnContentType(ctrl.targetClass, endpoint.methodClassName);
-
-
-                    let OpenAPIPath = `${endpointUrl}${getOpenAPIPath(endpoint.getRoute()) || ""}`;
-
-                    if (!paths[OpenAPIPath]) paths[OpenAPIPath] = {};
-
-                    paths[OpenAPIPath][endpoint.getMethod()] = {
-                        operationId: endpoint.methodClassName,
-                        tags: [className],
-                        parameters: getOpenAPIParams(parameters),
-                        consumes: [],
-                        responses: {"200": {description: ""}},
-                        produces: returnContentType ? [returnContentType] : []
-                    };
-
-                }
-            });
-
-        };
-
-        ControllerService
-            .controllers
-            .forEach((finalCtrl: Controller) => {
-
-                if (!finalCtrl.parent) {
-                    finalCtrl
-                        .getMountEndpoints()
-                        .map(endpoint => finalCtrl.getEndpointUrl(endpoint))
-                        .forEach(endpoint => buildRoutes(finalCtrl, endpoint));
-                }
-
-
-            });
-
-        openAPI.paths = paths;
-        return openAPI;
-    }
-
     /**
      * Print all route mounted in express via Annotation.
      */
-    public printRoutes(logger: {info: (s) => void} = $log): void {
+    public printRoutes(logger: { info: (s) => void } = $log): void {
 
         const mapColor = {
             GET: (<any>"GET").green,
@@ -455,5 +315,14 @@ export default class ControllerService {
 
         logger.info("\n" + str.trim());
 
+    }
+
+    /**
+     *
+     * @param callback
+     * @param thisArg
+     */
+    public forEach(callback, thisArg?) {
+        return ControllerService.controllers.forEach(callback, thisArg);
     }
 }

--- a/src/services/controller.ts
+++ b/src/services/controller.ts
@@ -1,3 +1,7 @@
+import {
+    BodyParameter, FormDataParameter, Parameter, Path, PathParameter, QueryParameter, Schema, Spec
+} from "@types/swagger-schema-official";
+
 import {Service} from "../decorators/service";
 import {ExpressApplication} from "./express-application";
 import Controller from "../controllers/controller";
@@ -278,6 +282,141 @@ export default class ControllerService {
         });
 
         return routes;
+    }
+
+
+    public getOpenAPISpec(): Spec {
+
+        let openAPI: Spec = {
+            "swagger": "2.0",
+            "info": {
+                "version": "1.0.0",
+                "title": "Swagger",
+            },
+            "paths": {}
+        };
+
+        let paths: { [pathName: string]: Path } = {};
+
+
+        const getOpenAPIPath = (expressPath: string | RegExp): string | RegExp => {
+            if (typeof expressPath === "string") {
+                let params = expressPath.match(/:[\w]+/g);
+
+                let OpenAPIPath = expressPath;
+                if (params) {
+                    let swagerParams = params.map(x => {
+                        return "{" + x.replace(":", "") + "}";
+                    });
+
+                    OpenAPIPath = params.reduce((acc, el, ix) => {
+                        return acc.replace(el, swagerParams[ix]);
+                    }, expressPath);
+                }
+                return OpenAPIPath;
+            } else {
+                return expressPath;
+            }
+        };
+
+        const getOpenAPIParams = (tsDecoratorsParams: any): Parameter[] => {
+            let OpenAPIParameters: Parameter[] = [];
+
+            let bodyParams: BodyParameter = {in: "", name: ""};
+
+            let notBodyParams: PathParameter | QueryParameter | FormDataParameter;
+            notBodyParams = {type: "", name: "", required: false, in: ""};
+
+            let hasBodyParams = false;
+            tsDecoratorsParams.forEach(p => {
+                switch (p.name) {
+                    case "parseParams":
+                        notBodyParams.in = "path";
+                        notBodyParams.required = true;
+                        notBodyParams.type = p.use ? p.use.name.toLowerCase() : "";
+                        break;
+                    case "parseBody":
+                        hasBodyParams = true;
+                        if (!bodyParams.schema) {
+                            bodyParams.schema = {};
+                            bodyParams.schema.properties = {};
+                        }
+                        let property: Schema = {
+                            type: p.use ? p.use.name.toLowerCase() : ""
+                        };
+                        bodyParams.schema.properties[p.expression] = property;
+                        if (p.required) {
+                            if (!bodyParams.schema.required) bodyParams.schema.required = [];
+                            bodyParams.schema.required.push(p.expression);
+                        }
+                        break;
+                    default:
+                        notBodyParams["in"] = "path";
+                        notBodyParams["type"] = p.use ? p.use.name.toLowerCase() : "";
+                }
+                notBodyParams.name = p.expression;
+                if (p.name !== "parseBody" && p.expression) {
+                    if (p.required) notBodyParams["required"] = true;
+                    OpenAPIParameters.push(notBodyParams);
+                }
+            });
+
+            if (hasBodyParams) {
+                bodyParams.in = "body";
+                bodyParams.name = "bodyParam";
+                bodyParams.schema.type = "object";
+                OpenAPIParameters.push(bodyParams);
+            }
+            return OpenAPIParameters;
+        };
+
+        const buildRoutes = (ctrl: Controller, endpointUrl: string) => {
+
+            ctrl.dependencies.forEach((ctrl: Controller) => buildRoutes(ctrl, `${endpointUrl}${ctrl.endpointUrl}`));
+
+            ctrl.endpoints.forEach((endpoint: Endpoint) => {
+
+                if (endpoint.hasMethod()) {
+
+                    const className = getClassName(ctrl.targetClass),
+                        parameters = InjectParams.getParams(ctrl.targetClass, endpoint.methodClassName),
+                        returnContentType = Metadata.getReturnContentType(ctrl.targetClass, endpoint.methodClassName);
+
+
+                    let OpenAPIPath = `${endpointUrl}${getOpenAPIPath(endpoint.getRoute()) || ""}`;
+
+                    if (!paths[OpenAPIPath]) paths[OpenAPIPath] = {};
+
+                    paths[OpenAPIPath][endpoint.getMethod()] = {
+                        operationId: endpoint.methodClassName,
+                        tags: [className],
+                        parameters: getOpenAPIParams(parameters),
+                        consumes: [],
+                        responses: {"200": {description: ""}},
+                        produces: returnContentType ? [returnContentType] : []
+                    };
+
+                }
+            });
+
+        };
+
+        ControllerService
+            .controllers
+            .forEach((finalCtrl: Controller) => {
+
+                if (!finalCtrl.parent) {
+                    finalCtrl
+                        .getMountEndpoints()
+                        .map(endpoint => finalCtrl.getEndpointUrl(endpoint))
+                        .forEach(endpoint => buildRoutes(finalCtrl, endpoint));
+                }
+
+
+            });
+
+        openAPI.paths = paths;
+        return openAPI;
     }
 
     /**

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -7,6 +7,7 @@ import RouteService from "./route";
 import ConverterService from "./converter";
 import MiddlewareService from "./middleware";
 import RouterController from "./router-controller";
+import SwaggerService from "./swagger";
 import Metadata from "./metadata";
 
 export {
@@ -19,6 +20,7 @@ export {
     ConverterService,
     MiddlewareService,
     RouterController,
+    SwaggerService,
     Metadata
 };
 

--- a/src/services/inject-params.ts
+++ b/src/services/inject-params.ts
@@ -60,22 +60,24 @@ export default class InjectParams {
         return this._name;
     }
 
+    get useName(): string {
+        return this.use ? getClassName(this.use) : undefined
+    }
+    get baseTypeName(): string {
+        return this.baseType && this.useName !== getClassName(this.baseType) ? getClassName(this.baseType) : undefined
+    }
     /**
      *
      * @returns {{service: (string|symbol), name: string, expression: string, required: boolean, use: undefined, baseType: undefined}}
      */
     toJSON() {
-
-        const use = this.use ? getClassName(this.use) : undefined;
-        const baseType = this.baseType && use !== getClassName(this.baseType) ? getClassName(this.baseType) : undefined;
-
         return {
             service: this._service,
             name: this._name,
             expression: this.expression,
             required: this.required,
-            use: use,
-            baseType: baseType
+            use: this.useName,
+            baseType: this.baseTypeName
         };
     }
 
@@ -96,7 +98,7 @@ export default class InjectParams {
 
     }
 
-    static getParams(target: any, targetKey: string | symbol): InjectParams {
+    static getParams(target: any, targetKey: string | symbol): InjectParams[] {
 
         return Metadata.has(INJECT_PARAMS, target, targetKey)
             ? Metadata.get(INJECT_PARAMS, target, targetKey)

--- a/src/services/inject-params.ts
+++ b/src/services/inject-params.ts
@@ -61,11 +61,13 @@ export default class InjectParams {
     }
 
     get useName(): string {
-        return this.use ? getClassName(this.use) : undefined
+        return this.use ? getClassName(this.use) : undefined;
     }
+
     get baseTypeName(): string {
-        return this.baseType && this.useName !== getClassName(this.baseType) ? getClassName(this.baseType) : undefined
+        return this.baseType && this.useName !== getClassName(this.baseType) ? getClassName(this.baseType) : undefined;
     }
+
     /**
      *
      * @returns {{service: (string|symbol), name: string, expression: string, required: boolean, use: undefined, baseType: undefined}}

--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -1,5 +1,5 @@
 import {
-    DESIGN_PARAM_TYPES, DESIGN_RETURN_CONTENT_TYPE, DESIGN_RETURN_TYPE, DESIGN_TYPE
+    DESIGN_PARAM_TYPES, DESIGN_RETURN_TYPE, DESIGN_TYPE
 } from "../constants/metadata-keys";
 import {getClass} from "../utils/utils";
 require("reflect-metadata");

--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -85,14 +85,6 @@ export default class Metadata<T> {
      *
      * @param target
      * @param propertyKey
-     */
-    static getReturnContentType = (target: any, propertyKey: string | symbol): string =>
-        Reflect.getMetadata(DESIGN_RETURN_CONTENT_TYPE, target, propertyKey);
-
-    /**
-     *
-     * @param target
-     * @param propertyKey
      * @returns {any}
      */
     static getParamTypes(target: any, propertyKey?: string): any[] {

--- a/src/services/metadata.ts
+++ b/src/services/metadata.ts
@@ -1,4 +1,6 @@
-import {DESIGN_PARAM_TYPES, DESIGN_RETURN_TYPE, DESIGN_TYPE} from "../constants/metadata-keys";
+import {
+    DESIGN_PARAM_TYPES, DESIGN_RETURN_CONTENT_TYPE, DESIGN_RETURN_TYPE, DESIGN_TYPE
+} from "../constants/metadata-keys";
 import {getClass} from "../utils/utils";
 require("reflect-metadata");
 
@@ -78,6 +80,14 @@ export default class Metadata<T> {
      */
     static getReturnType = (target: any, propertyKey: string | symbol): any =>
         Reflect.getMetadata(DESIGN_RETURN_TYPE, target, propertyKey);
+
+    /**
+     *
+     * @param target
+     * @param propertyKey
+     */
+    static getReturnContentType = (target: any, propertyKey: string | symbol): string =>
+        Reflect.getMetadata(DESIGN_RETURN_CONTENT_TYPE, target, propertyKey);
 
     /**
      *

--- a/src/services/route.ts
+++ b/src/services/route.ts
@@ -1,4 +1,4 @@
-
+import {Spec} from "@types/swagger-schema-official";
 import {Service} from "../decorators/service";
 import {IControllerRoute} from "../interfaces/ControllerRoute";
 import {$log} from "ts-log-debug";
@@ -20,6 +20,14 @@ export default class RouteService {
      */
     getAll(): IControllerRoute[] {
         return this.controllerService.getRoutes();
+    }
+
+    /**
+     * Return openAPISpec for routes stored in Controller manager.
+     * @returns {Spec}
+     */
+    getOpenAPISpec(): Spec {
+        return this.controllerService.getOpenAPISpec();
     }
 
     /**

--- a/src/services/route.ts
+++ b/src/services/route.ts
@@ -1,4 +1,3 @@
-import {Spec} from "@types/swagger-schema-official";
 import {Service} from "../decorators/service";
 import {IControllerRoute} from "../interfaces/ControllerRoute";
 import {$log} from "ts-log-debug";
@@ -20,14 +19,6 @@ export default class RouteService {
      */
     getAll(): IControllerRoute[] {
         return this.controllerService.getRoutes();
-    }
-
-    /**
-     * Return openAPISpec for routes stored in Controller manager.
-     * @returns {Spec}
-     */
-    getOpenAPISpec(): Spec {
-        return this.controllerService.getOpenAPISpec();
     }
 
     /**

--- a/src/services/swagger.ts
+++ b/src/services/swagger.ts
@@ -7,7 +7,6 @@ import Controller from "../controllers/controller";
 import {Endpoint} from "../controllers/endpoint";
 import {getClassName} from "../utils/utils";
 import InjectParams from "./inject-params";
-import Metadata from "./metadata";
 import {Inject} from "../decorators/inject";
 import {ExpressApplication} from "./express-application";
 import {ServerSettingsService} from "./server-settings";
@@ -166,12 +165,13 @@ export default class SwaggerService {
 
             if (endpoint.hasMethod()) {
 
+                // get Api Info collected by decorators
+                const {produces = [], consumes = []} = endpoint.getApiInfo();
+
                 const className = getClassName(ctrl.targetClass),
-                    parameters = InjectParams.getParams(ctrl.targetClass, endpoint.methodClassName),
-                    returnContentType = Metadata.getReturnContentType(ctrl.targetClass, endpoint.methodClassName);
+                    parameters = InjectParams.getParams(ctrl.targetClass, endpoint.methodClassName);
 
-
-                let OpenAPIPath = `${endpointUrl}${this.getOpenApiPath(endpoint.getRoute()) || ""}`;
+                const OpenAPIPath = `${endpointUrl}${this.getOpenApiPath(endpoint.getRoute()) || ""}`;
 
                 if (!paths[OpenAPIPath]) paths[OpenAPIPath] = {};
 
@@ -179,9 +179,9 @@ export default class SwaggerService {
                     operationId: endpoint.methodClassName,
                     tags: [className],
                     parameters: this.getOpenApiParams(parameters),
-                    consumes: [],
+                    consumes,
                     responses: {"200": {description: ""}},
-                    produces: returnContentType ? [returnContentType] : []
+                    produces
                 };
 
             }

--- a/src/services/swagger.ts
+++ b/src/services/swagger.ts
@@ -1,0 +1,192 @@
+import {
+    BodyParameter, FormDataParameter, Parameter, Path, PathParameter, QueryParameter, Schema, Spec
+} from "swagger-schema-official";
+import {Service} from "../decorators/service";
+import ControllerService from "./controller";
+import Controller from "../controllers/controller";
+import {Endpoint} from "../controllers/endpoint";
+import {getClassName} from "../utils/utils";
+import InjectParams from "./inject-params";
+import Metadata from "./metadata";
+import {Inject} from "../decorators/inject";
+import {ExpressApplication} from "./express-application";
+import {ServerSettingsService} from "./server-settings";
+
+export interface SwaggerPaths {
+    [pathName: string]: Path;
+}
+
+export interface SwaggerSettings {
+    path: string;
+    setup?: any;
+}
+
+@Service()
+export default class SwaggerService {
+
+    constructor(private controllerService: ControllerService,
+                private serverSettingsService: ServerSettingsService,
+                @Inject(ExpressApplication) private expressApplication: ExpressApplication) {
+
+    }
+
+    load() {
+        const conf = this.serverSettingsService.get<SwaggerSettings>("swagger");
+
+        if (conf) {
+            const swaggerUiMiddleware = require("swagger-ui-express");
+
+            this.expressApplication.use(
+                conf.path,
+                swaggerUiMiddleware.serve,
+                swaggerUiMiddleware.setup(conf || {})
+            );
+        }
+
+        this.expressApplication.get("/swagger.json", (req, res, next) => {
+            const content = this.getOpenAPISpec();
+            res.status(200).json(content);
+            next();
+        });
+    }
+
+    public getOpenAPISpec(): Spec {
+
+        let openAPI: Spec = {
+            "swagger": "2.0",
+            "info": {
+                "version": "1.0.0",
+                "title": "Swagger",
+            },
+            "paths": {}
+        };
+
+        let paths: SwaggerPaths = {};
+
+        this.controllerService
+            .forEach((finalCtrl: Controller) => {
+
+                if (!finalCtrl.parent) {
+                    finalCtrl
+                        .getMountEndpoints()
+                        .map(endpoint => finalCtrl.getEndpointUrl(endpoint))
+                        .forEach(endpoint => this.buildRoutes(paths, finalCtrl, endpoint));
+                }
+
+
+            });
+
+        openAPI.paths = paths;
+        return openAPI;
+    }
+
+    public getOpenApiPath = (expressPath: string | RegExp): string | RegExp => {
+        if (typeof expressPath === "string") {
+            let params = expressPath.match(/:[\w]+/g);
+
+            let OpenAPIPath = expressPath;
+            if (params) {
+                let swagerParams = params.map(x => {
+                    return "{" + x.replace(":", "") + "}";
+                });
+
+                OpenAPIPath = params.reduce((acc, el, ix) => {
+                    return acc.replace(el, swagerParams[ix]);
+                }, expressPath);
+            }
+            return OpenAPIPath;
+        } else {
+            return expressPath;
+        }
+    };
+
+    public getOpenApiParams = (tsDecoratorsParams: any): Parameter[] => {
+        let OpenAPIParameters: Parameter[] = [];
+
+        let bodyParams: BodyParameter = {in: "", name: ""};
+
+        let notBodyParams: PathParameter | QueryParameter | FormDataParameter;
+        notBodyParams = {type: "", name: "", required: false, in: ""};
+
+        let hasBodyParams = false;
+        tsDecoratorsParams.forEach(p => {
+            switch (p.name) {
+                case "parseParams":
+                    notBodyParams.in = "path";
+                    notBodyParams.required = true;
+                    notBodyParams.type = p.use ? p.use.name.toLowerCase() : "";
+                    break;
+                case "parseBody":
+                    hasBodyParams = true;
+                    if (!bodyParams.schema) {
+                        bodyParams.schema = {};
+                        bodyParams.schema.properties = {};
+                    }
+                    let property: Schema = {
+                        type: p.use ? p.use.name.toLowerCase() : ""
+                    };
+                    bodyParams.schema.properties[p.expression] = property;
+                    if (p.required) {
+                        if (!bodyParams.schema.required) bodyParams.schema.required = [];
+                        bodyParams.schema.required.push(p.expression);
+                    }
+                    break;
+                default:
+                    notBodyParams["in"] = "path";
+                    notBodyParams["type"] = p.use ? p.use.name.toLowerCase() : "";
+            }
+            notBodyParams.name = p.expression;
+            if (p.name !== "parseBody" && p.expression) {
+                if (p.required) notBodyParams["required"] = true;
+                OpenAPIParameters.push(notBodyParams);
+            }
+        });
+
+        if (hasBodyParams) {
+            bodyParams.in = "body";
+            bodyParams.name = "bodyParam";
+            bodyParams.schema.type = "object";
+            OpenAPIParameters.push(bodyParams);
+        }
+        return OpenAPIParameters;
+    };
+
+    /**
+     *
+     * @param paths
+     * @param ctrl
+     * @param endpointUrl
+     */
+    public buildRoutes = (paths: SwaggerPaths, ctrl: Controller, endpointUrl: string) => {
+
+        ctrl.dependencies
+            .forEach((ctrl: Controller) => this.buildRoutes(paths, ctrl, `${endpointUrl}${ctrl.endpointUrl}`));
+
+        ctrl.endpoints.forEach((endpoint: Endpoint) => {
+
+            if (endpoint.hasMethod()) {
+
+                const className = getClassName(ctrl.targetClass),
+                    parameters = InjectParams.getParams(ctrl.targetClass, endpoint.methodClassName),
+                    returnContentType = Metadata.getReturnContentType(ctrl.targetClass, endpoint.methodClassName);
+
+
+                let OpenAPIPath = `${endpointUrl}${this.getOpenApiPath(endpoint.getRoute()) || ""}`;
+
+                if (!paths[OpenAPIPath]) paths[OpenAPIPath] = {};
+
+                paths[OpenAPIPath][endpoint.getMethod()] = {
+                    operationId: endpoint.methodClassName,
+                    tags: [className],
+                    parameters: this.getOpenApiParams(parameters),
+                    consumes: [],
+                    responses: {"200": {description: ""}},
+                    produces: returnContentType ? [returnContentType] : []
+                };
+
+            }
+        });
+
+    };
+
+}

--- a/src/services/swagger.ts
+++ b/src/services/swagger.ts
@@ -1,84 +1,175 @@
 import {
-    BodyParameter, FormDataParameter, Parameter, Path, PathParameter, QueryParameter, Schema, Spec
+    BodyParameter, FormDataParameter, Parameter, Path, PathParameter, QueryParameter, Schema, Spec, Info, Contact,
+    ExternalDocs, Security, Tag, BaseParameter
 } from "swagger-schema-official";
+import * as Fs from "fs";
+import * as PathUtils from "path";
 import {Service} from "../decorators/service";
 import ControllerService from "./controller";
 import Controller from "../controllers/controller";
 import {Endpoint} from "../controllers/endpoint";
-import {getClassName} from "../utils/utils";
+import {deepExtends, getClassName} from "../utils/utils";
 import InjectParams from "./inject-params";
 import {Inject} from "../decorators/inject";
 import {ExpressApplication} from "./express-application";
 import {ServerSettingsService} from "./server-settings";
+import {inject} from "../testing/inject";
+import ParseService from "./parse";
+import {type} from "os";
 
-export interface SwaggerPaths {
+export interface ISwaggerPaths {
     [pathName: string]: Path;
 }
 
-export interface SwaggerSettings {
+export interface ISwaggerSettings {
     path: string;
-    setup?: any;
+    cssPath?: string;
+    options?: any;
+    showExplorer?: boolean;
+    specPath?: string;
+    spec?: {
+        swagger?: string;
+        info?: Info;
+        externalDocs?: ExternalDocs;
+        host?: string;
+        basePath?: string;
+        schemes?: string[];
+        consumes?: string[];
+        produces?: string[];
+        paths?: { [pathName: string]: Path };
+        definitions?: { [definitionsName: string]: Schema };
+        parameters?: { [parameterName: string]: BodyParameter | QueryParameter };
+        responses?: { [responseName: string]: Response };
+        security?: Array<{ [securityDefinitionName: string]: string[] }>;
+        securityDefinitions?: { [securityDefinitionName: string]: Security };
+        tags?: Tag[];
+    };
 }
 
 @Service()
 export default class SwaggerService {
 
+    MODEL_AUTO_INCREMENT = 1;
+
     constructor(private controllerService: ControllerService,
                 private serverSettingsService: ServerSettingsService,
+                private parseService: ParseService,
                 @Inject(ExpressApplication) private expressApplication: ExpressApplication) {
 
     }
 
     load() {
-        const conf = this.serverSettingsService.get<SwaggerSettings>("swagger");
+        const conf = this.serverSettingsService.get<ISwaggerSettings>("swagger");
 
         if (conf) {
             const swaggerUiMiddleware = require("swagger-ui-express");
+            let cssContent;
+
+            if (conf.cssPath) {
+                cssContent = Fs.readFileSync(PathUtils.resolve(this.serverSettingsService.resolve(conf.cssPath)));
+            }
 
             this.expressApplication.use(
                 conf.path,
                 swaggerUiMiddleware.serve,
-                swaggerUiMiddleware.setup(conf || {})
+                swaggerUiMiddleware.setup(this.getOpenAPISpec(), conf.showExplorer, conf.options, cssContent)
             );
         }
 
         this.expressApplication.get("/swagger.json", (req, res, next) => {
-            const content = this.getOpenAPISpec();
-            res.status(200).json(content);
-            next();
+            try {
+                const content = this.getOpenAPISpec();
+                res.status(200).json(content);
+
+                next();
+            } catch (er) {
+                console.error(er);
+                next(er);
+            }
         });
     }
 
+    /**
+     *
+     * @param out
+     * @param args
+     * @returns {any}
+     */
+
+
+    /**
+     *
+     * @returns {Spec}
+     */
     public getOpenAPISpec(): Spec {
-
-        let openAPI: Spec = {
-            "swagger": "2.0",
-            "info": {
-                "version": "1.0.0",
-                "title": "Swagger",
-            },
-            "paths": {}
-        };
-
-        let paths: SwaggerPaths = {};
+        const {specPath, spec = {}} = this.serverSettingsService.get<ISwaggerSettings>("swagger");
+        const consumes = this.serverSettingsService.acceptMimes;
+        const produces = ["application/json"];
+        const info = this.getOpenApiInfo();
+        let specPathContent = {};
+        let paths: ISwaggerPaths = {};
+        let definitions = {};
 
         this.controllerService
             .forEach((finalCtrl: Controller) => {
-
                 if (!finalCtrl.parent) {
                     finalCtrl
                         .getMountEndpoints()
                         .map(endpoint => finalCtrl.getEndpointUrl(endpoint))
-                        .forEach(endpoint => this.buildRoutes(paths, finalCtrl, endpoint));
+                        .forEach(endpoint => this.buildRoutes(paths, definitions, finalCtrl, endpoint));
                 }
-
-
             });
 
-        openAPI.paths = paths;
-        return openAPI;
+        if (specPath) {
+            specPathContent = require(this.serverSettingsService.resolve(specPath));
+        }
+
+        return deepExtends(
+            {swagger: "2.0"},
+            specPathContent,
+            spec,
+            {
+                info,
+                consumes,
+                produces,
+                paths,
+                definitions
+            }
+        );
     }
 
+    /**
+     * Return the global api information.
+     * @returns {Info}
+     */
+    public getOpenApiInfo(): Info {
+        const {version} = this.serverSettingsService;
+        const {spec} = this.serverSettingsService.get<ISwaggerSettings>("swagger") || {} as any;
+
+        const {
+            title = "Api documentation",
+            description = "",
+            version: versionInfo,
+            termsOfService = "",
+            contact,
+            license
+        } = spec.info || {} as any;
+
+        return {
+            version: versionInfo || version,
+            title,
+            description,
+            termsOfService,
+            contact,
+            license
+        };
+    }
+
+    /**
+     *
+     * @param expressPath
+     * @returns {any}
+     */
     public getOpenApiPath = (expressPath: string | RegExp): string | RegExp => {
         if (typeof expressPath === "string") {
             let params = expressPath.match(/:[\w]+/g);
@@ -98,68 +189,179 @@ export default class SwaggerService {
             return expressPath;
         }
     };
+    /**
+     *
+     * @param injectedParams
+     * @param definitions
+     * @returns {Parameter[]}
+     */
+    public getOpenApiParams = (injectedParams: InjectParams[], definitions: { [key: string]: Schema }): Parameter[] => {
+        let openAPIParameters: Parameter[] = [];
+        let bodySchema: Schema;
 
-    public getOpenApiParams = (tsDecoratorsParams: any): Parameter[] => {
-        let OpenAPIParameters: Parameter[] = [];
+        openAPIParameters = <Parameter[]> injectedParams
+            .map((param: InjectParams) => {
+                const inType = {
+                    "parseBody": "body",
+                    "parseParams": "path",
+                    "parseQuery": "query",
+                    "getHeader": "header"
+                }[param.name];
 
-        let bodyParams: BodyParameter = {in: "", name: ""};
-
-        let notBodyParams: PathParameter | QueryParameter | FormDataParameter;
-        notBodyParams = {type: "", name: "", required: false, in: ""};
-
-        let hasBodyParams = false;
-        tsDecoratorsParams.forEach(p => {
-            switch (p.name) {
-                case "parseParams":
-                    notBodyParams.in = "path";
-                    notBodyParams.required = true;
-                    notBodyParams.type = p.use ? p.use.name.toLowerCase() : "";
-                    break;
-                case "parseBody":
-                    hasBodyParams = true;
-                    if (!bodyParams.schema) {
-                        bodyParams.schema = {};
-                        bodyParams.schema.properties = {};
-                    }
-                    let property: Schema = {
-                        type: p.use ? p.use.name.toLowerCase() : ""
+                if (inType === undefined) { // not a input paramaters
+                    console.log("inType", inType, param.name);
+                    return;
+                }
+                if (inType === "body") {
+                    bodySchema = this.createSchema(param);
+                } else {
+                    const schema = this.mapParam(param);
+                    console.log(schema)
+                    return {
+                        "in": inType,
+                        ...schema
                     };
-                    bodyParams.schema.properties[p.expression] = property;
-                    if (p.required) {
-                        if (!bodyParams.schema.required) bodyParams.schema.required = [];
-                        bodyParams.schema.required.push(p.expression);
-                    }
-                    break;
-                default:
-                    notBodyParams["in"] = "path";
-                    notBodyParams["type"] = p.use ? p.use.name.toLowerCase() : "";
-            }
-            notBodyParams.name = p.expression;
-            if (p.name !== "parseBody" && p.expression) {
-                if (p.required) notBodyParams["required"] = true;
-                OpenAPIParameters.push(notBodyParams);
-            }
-        });
+                }
+            })
+            .filter(o => !!o);
 
-        if (hasBodyParams) {
-            bodyParams.in = "body";
-            bodyParams.name = "bodyParam";
-            bodyParams.schema.type = "object";
-            OpenAPIParameters.push(bodyParams);
+        if (bodySchema) {
+            let bodyParam: BodyParameter = {} as BodyParameter;
+            // model name will be extract from metadata in future.
+            const model = `Model${this.MODEL_AUTO_INCREMENT}`;
+
+            bodyParam.in = "body";
+            bodyParam.name = "body";
+            bodyParam["$ref"] = `#/definitions/${model}`;
+            bodyParam.description = "";
+            bodyParam.required = true;
+            openAPIParameters.push(bodyParam);
+
+            definitions[model] = bodySchema;
+
+            this.MODEL_AUTO_INCREMENT++;
         }
-        return OpenAPIParameters;
+
+
+        return openAPIParameters;
     };
 
     /**
      *
+     * @param param
+     * @returns {T&{}}
+     */
+    private mapParam(param: InjectParams) {
+        const {
+            required,
+            useName,
+            expression
+        }
+            = param;
+
+        return {
+            name: expression,
+            required,
+            description: "",
+            type: this.swaggerType(useName)
+        };
+    }
+
+    /**
+     *
+     * @param param
+     */
+    /*mapBopyParam(param: InjectParams) {
+     const {required, useName: type} = param;
+
+     const body = {properties: {}};
+
+     if (!schema) {
+     bodyParams.schema = {};
+     bodyParams.schema.properties = {};
+     }
+     const property: Schema = {
+     type
+     };
+
+     this.parseService.eval(ex);
+
+     bodyParams.schema.properties[p.expression] = property;
+     if (p.required) {
+     if (!bodyParams.schema.required) bodyParams.schema.required = [];
+     bodyParams.schema.required.push(p.expression);
+     }
+     }*/
+
+    /**
+     *
+     * @param param
+     * @returns {Schema}
+     */
+    private createSchema(param: InjectParams) {
+        const {
+            required,
+            useName,
+            baseTypeName,
+            expression
+        }
+            = param;
+        const keys = (expression as string).split(".");
+        const output: Schema = {
+            type: "object",
+            properties: {}
+        };
+        let current = output;
+
+        keys.forEach((key, index) => {
+            current[key] = <Schema> {};
+
+            if (index < keys.length - 1) {
+                current.properties = {};
+                current = current[key].properties;
+            }
+        });
+
+        if (baseTypeName === "Array") {
+            Object.assign(current, {
+                type: "array",
+                items: {
+                    type: this.swaggerType(useName)
+                }
+            });
+        } else {
+            Object.assign(current, {
+                type: this.swaggerType(useName)
+            });
+        }
+
+        Object.assign(current, {
+            required
+        });
+
+        return output;
+    }
+
+    swaggerType(type: string): string {
+        if (["Array", "Boolean", "Object", "Number", "String"].indexOf(type) > -1) {
+            return type.toLowerCase();
+        }
+
+        // in type case the type is complexe
+        return type;
+    }
+
+    /**
+     *
      * @param paths
+     * @param definitions
      * @param ctrl
      * @param endpointUrl
      */
-    public buildRoutes = (paths: SwaggerPaths, ctrl: Controller, endpointUrl: string) => {
+    public buildRoutes = (paths: ISwaggerPaths, definitions: { [key: string]: Schema }, ctrl: Controller, endpointUrl: string) => {
 
         ctrl.dependencies
-            .forEach((ctrl: Controller) => this.buildRoutes(paths, ctrl, `${endpointUrl}${ctrl.endpointUrl}`));
+            .forEach((ctrl: Controller) => this.buildRoutes(paths, definitions, ctrl, `${endpointUrl}${ctrl.endpointUrl}`));
 
         ctrl.endpoints.forEach((endpoint: Endpoint) => {
 
@@ -169,7 +371,10 @@ export default class SwaggerService {
                 const {produces = [], consumes = []} = endpoint.getApiInfo();
 
                 const className = getClassName(ctrl.targetClass),
-                    parameters = InjectParams.getParams(ctrl.targetClass, endpoint.methodClassName);
+                    parameters = this.getOpenApiParams(
+                        InjectParams.getParams(ctrl.targetClass, endpoint.methodClassName),
+                        definitions
+                    );
 
                 const OpenAPIPath = `${endpointUrl}${this.getOpenApiPath(endpoint.getRoute()) || ""}`;
 
@@ -178,7 +383,7 @@ export default class SwaggerService {
                 paths[OpenAPIPath][endpoint.getMethod()] = {
                     operationId: endpoint.methodClassName,
                     tags: [className],
-                    parameters: this.getOpenApiParams(parameters),
+                    parameters,
                     consumes,
                     responses: {"200": {description: ""}},
                     produces

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -27,7 +27,7 @@ export const getContructor = (targetClass: any): Function =>
  * @returns {*}
  */
 export function getClass(target: any): any {
-   return target.prototype ? target : target.constructor;
+    return target.prototype ? target : target.constructor;
 }
 
 export function getClassOrSymbol(target: any): any {
@@ -90,4 +90,38 @@ export function isCollection(target): boolean {
  */
 export function isEmpty(value: any): boolean {
     return value === "" || value === null || value === undefined;
+}
+
+export function deepExtends(out, ...args) {
+    out = out || {};
+
+    args.forEach(obj => {
+        if (obj === undefined || obj === null) {
+            return;
+        }
+
+        Object.keys(obj).forEach(key => {
+            const value = obj[key];
+
+            if (value === undefined || value === null) {
+                return;
+            }
+
+            if (isPrimitiveOrPrimitiveClass(value) || typeof value === "function") {
+                out[key] = value;
+                return;
+            }
+
+            if (isArrayOrArrayClass(value)) {
+                // TODO Maybe use reduce ?
+                out[key] = [].concat(out[key] || [], value);
+                return;
+            }
+
+            // Object
+            out[key] = deepExtends(out[key], value);
+        });
+    });
+
+    return out;
 }

--- a/test/helper/app.ts
+++ b/test/helper/app.ts
@@ -27,6 +27,9 @@ const rootDir = Path.resolve(__dirname);
     serveStatic: {
         "/": `${rootDir}/views`
     },
+    swagger: {
+        path: "/api-docs"
+    },
     debug: true
 })
 export class ExampleServer extends ServerLoader {
@@ -44,7 +47,6 @@ export class ExampleServer extends ServerLoader {
             session = require("express-session");
 
         this
-        // .use(morgan('dev'))
             .use(TestAcceptMimeMiddleware)
             .use(bodyParser.json())
             .use(bodyParser.urlencoded({
@@ -57,6 +59,8 @@ export class ExampleServer extends ServerLoader {
         this.engine(".html", require("ejs").__express)
             .set("views", "./views")
             .set("view engine", "html");
+
+
     }
 
     /**
@@ -69,7 +73,8 @@ export class ExampleServer extends ServerLoader {
     public $onAuth(request: Express.Request, response: Express.Response, next: Express.NextFunction): void {
 
         next(true);
-        next(true); request.get("authorization") === "token";
+        next(true);
+        request.get("authorization") === "token";
     }
 
     /**

--- a/test/helper/app.ts
+++ b/test/helper/app.ts
@@ -10,6 +10,7 @@ $log.setPrintDate(true);
 const rootDir = Path.resolve(__dirname);
 
 @ServerSettings({
+    version: "1.1.0",
     rootDir,
     port: 8000,
     httpsPort: 8080,
@@ -27,8 +28,17 @@ const rootDir = Path.resolve(__dirname);
     serveStatic: {
         "/": `${rootDir}/views`
     },
+
     swagger: {
-        path: "/api-docs"
+        path: "/api-docs",
+        spec: {
+            info: {
+                title: "An application",
+                contact: {
+                    email: "team@team.fr"
+                }
+            }
+        }
     },
     debug: true
 })

--- a/test/helper/controllers/RestCtrl.ts
+++ b/test/helper/controllers/RestCtrl.ts
@@ -1,22 +1,22 @@
-import {Render, Controller, All, Get, RouteService} from "../../../src";
+import {All, Controller, Get, Render, RouteService} from "../../../src";
+import SwaggerService from "../../../src/services/swagger";
 
 @Controller("/rest")
 export class RestCtrl {
 
-    constructor (
-        private routeService: RouteService
-    ) {
+    constructor(private routeService: RouteService, private swaggerService: SwaggerService) {
 
     }
 
-    @All('/')
+    @All("/")
     public test(): Object {
         return this.routeService.getAll();
     }
 
-    @Get('/html')
+    @Get("/html")
     @Render("rest")
     public render() {
         return {endpoints: JSON.parse(JSON.stringify(this.routeService.getAll()))};
     }
+
 }

--- a/test/helper/controllers/calendars/CalendarCtrl.ts
+++ b/test/helper/controllers/calendars/CalendarCtrl.ts
@@ -145,7 +145,7 @@ export class CalendarCtrl {
                                    @Response() response: Express.Response,
                                    @PathParams("id") id: string): IPromise<ICalendar> {
 
-        //$log.debug("ID =>", id, request.params.id);
+        // $log.debug("ID =>", id, request.params.id);
         //
         return new Promise<ICalendar>((resolve, reject) => {
 
@@ -176,14 +176,14 @@ export class CalendarCtrl {
 
     /**
      *
-     * @param auth
      * @param name
+     * @param alias
      * @returns {{id: number, name: string}}
      */
     @Put("/")
-    public save(@BodyParams("name") @Required() name: string): any {
+    public save(@BodyParams("name") @Required() name: string, @BodyParams("alias") alias?: string): any {
 
-        return {id: 2, name: name};
+        return {id: 2, name: name, alias: alias};
     }
 
 
@@ -210,7 +210,7 @@ export class CalendarCtrl {
 
         request["user"] = 1;
 
-        //console.log(request.headers)
+        // console.log(request.headers)
         next();
     }
 

--- a/test/helper/controllers/calendars/EventCtrl.ts
+++ b/test/helper/controllers/calendars/EventCtrl.ts
@@ -56,9 +56,9 @@ export class EventCtrl {
      * @returns {null}
      */
     @Post("/:id")
-    update(@BodyParams("event", EventModel) event: EventModel[]): EventModel[] {
+    update(@BodyParams("events", EventModel) events: EventModel[]): EventModel[] {
 
-        return event;
+        return events;
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,6 +1742,10 @@ swagger-schema-official@^2.0.0-bab6bed:
   version "2.0.0-d79c205"
   resolved "https://registry.yarnpkg.com/swagger-schema-official/-/swagger-schema-official-2.0.0-d79c205.tgz#465e81bedf5d4874a423ef3c6041c606bbc3f2fd"
 
+swagger-ui-express@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/swagger-ui-express/-/swagger-ui-express-2.0.0.tgz#560f289bb6420b3475674a39fdd91d99ee30ced5"
+
 term-size@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-0.1.1.tgz#87360b96396cab5760963714cda0d0cbeecad9ca"

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,10 @@
   dependencies:
     "@types/superagent" "*"
 
+"@types/swagger-schema-official@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/swagger-schema-official/-/swagger-schema-official-2.0.5.tgz#9fe49b40b1d033fd73bebb7bb69cfa8cbf30b9f1"
+
 abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
@@ -1733,6 +1737,10 @@ supports-color@^3.1.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+swagger-schema-official@^2.0.0-bab6bed:
+  version "2.0.0-d79c205"
+  resolved "https://registry.yarnpkg.com/swagger-schema-official/-/swagger-schema-official-2.0.0-d79c205.tgz#465e81bedf5d4874a423ef3c6041c606bbc3f2fd"
 
 term-size@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
NO

## Description
Generate swagger documentation from metadata

## Usage example
Example to use your feature and to improve the documentation after merging your PR:
Install swagger-ui-express:
```bash
npm install --save swagger-ui-express
```
And add configuration on your ServerSettings:
```typescript
import {} from "ts-express-decorators";

@ServerSettings({
    rootDir,
    swagger: {
        path: "/api-docs"
    }
})
export class Server extends ServerLoader {

}
```
## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
vologab:feature/#26_openAPI_spec_genration | [link](https://github.com/Romakita/ts-express-decorators/pull/71)

## Todos
- [x] Tests
- [ ] Documentation