### PR TITLE
fix(mvc): Fix building Endpoint when class inherit from a parent class

### DIFF
--- a/docs/docs/controllers.md
+++ b/docs/docs/controllers.md
@@ -322,3 +322,33 @@ class EventCtrl {
 
 > CaseSensitive and Strict options are also supported.
 
+## Inheritance
+
+Ts.ED support the ES6 inheritance class. So you can declare a controller that implement some generic method
+and use it on a children class.
+
+
+To do that just declare a parent controller without the `@Controller` decorator.
+```typescript
+export abstract class BaseController {
+    constructor(private someService: SomeService) {}
+    
+    @Get('/list')
+    async list(@QueryParams("search") search: any) {
+        return someService.list(search)
+    }
+}
+```
+
+Then, on your children controller:
+
+```typescript
+@Controller('/children')
+export abstract class ChildrenCtrl extends BaseController {
+    @Get('/:id')
+    async get(@PathParams("id") id: string): Promise<any> {
+      return {id: id}  
+    }
+}
+```
+

--- a/src/core/class/EntityDescription.ts
+++ b/src/core/class/EntityDescription.ts
@@ -29,23 +29,10 @@ export abstract class EntityDescription {
     constructor(protected _target: Type<any>,
                 protected _propertyKey: string | symbol,
                 protected _index?: any) {
-        let type;
 
-        if (typeof this._index === "number") {
-            type = Metadata.getParamTypes(_target, _propertyKey)[this._index];
-        } else {
-            type = Metadata.getType(_target, _propertyKey);
-        }
-
-        if (isCollection(type)) {
-            this._collectionType = type;
-            this._type = Object;
-        } else {
-            this._type = type;
-        }
-
-        this._name = nameOf(_propertyKey);
+        this.target = _target;
     }
+
 
     /**
      *
@@ -61,6 +48,30 @@ export abstract class EntityDescription {
      */
     public get target(): Type<any> {
         return getClass(this._target);
+    }
+
+    /**
+     *
+     * @param {Type<any>} target
+     */
+    public set target(target: Type<any>) {
+        this._target = target;
+        let type;
+
+        if (typeof this._index === "number") {
+            type = Metadata.getParamTypes(this._target, this._propertyKey)[this._index];
+        } else {
+            type = Metadata.getType(this._target, this._propertyKey);
+        }
+
+        if (isCollection(type)) {
+            this._collectionType = type;
+            this._type = Object;
+        } else {
+            this._type = type;
+        }
+
+        this._name = nameOf(this._propertyKey);
     }
 
     /**

--- a/src/core/class/Metadata.ts
+++ b/src/core/class/Metadata.ts
@@ -1,35 +1,10 @@
 /**
  * @module common/core
  */
-/** */
 import "reflect-metadata";
 import {getClass} from "../utils";
 
-/**
- * Metadata key
- * @private
- * @type {string}
- */
-const DESIGN_PARAM_TYPES = "design:paramtypes";
-/**
- * Metadata key
- * @private
- * @type {string}
- */
-const DESIGN_TYPE = "design:type";
-/**
- * Metadata key
- * @private
- * @type {string}
- */
-const DESIGN_RETURN_TYPE = "design:returntype";
-/**
- * Properties collections
- * @private
- * @type {string}
- */
-const PROPERTIES: Map<string | symbol, any[]> = new Map<string | symbol, any[]>();
-
+/** */
 /**
  * @stable
  */
@@ -69,8 +44,49 @@ export class Metadata {
      * ```
      *
      */
-    static get = (key: string, target: any, propertyKey?: string | symbol): any =>
-        Reflect.getMetadata(key, getClass(target), propertyKey!);
+    static get(key: string, target: any, propertyKey?: string | symbol): any {
+        return Reflect.getMetadata(key, getClass(target), propertyKey!);
+    }
+
+    /**
+     * Gets the metadata value for the provided metadata key on the target object or its prototype chain.
+     * @param key A key used to store and retrieve metadata.
+     * @param target The target object on which the metadata is defined.
+     * @param propertyKey The property key for the target.
+     * @returns The metadata value for the metadata key if found; otherwise, `undefined`.
+     * @example
+     *
+     * ```typescript
+     * class Example {
+     *     // property declarations are not part of ES6, though they are valid in TypeScript:
+     *     // static staticProperty;
+     *     // property;
+     *
+     *     static staticMethod(p) { }
+     *     method(p) { }
+     * }
+     *
+     * // constructor
+     * result = Metadata.getOwn("custom:annotation", Example);
+     *
+     * // property (on constructor)
+     * result = Metadata.getOwn("custom:annotation", Example, "staticProperty");
+     *
+     * // property (on prototype)
+     * result = Metadata.getOwn("custom:annotation", Example.prototype, "property");
+     *
+     * // method (on constructor)
+     * result = Metadata.getOwn("custom:annotation", Example, "staticMethod");
+     *
+     * // method (on prototype)
+     * result = Metadata.getOwn("custom:annotation", Example.prototype, "method");
+     * ```
+     *
+     */
+    static getOwn(key: string, target: any, propertyKey?: string | symbol): any {
+        return Reflect.getOwnMetadata(key, getClass(target), propertyKey!);
+    }
+
     /**
      * Gets the metadata value for the provided metadata DESIGN_TYPE on the target object or its prototype chain.
      * @param target The target object on which the metadata is defined.
@@ -99,8 +115,42 @@ export class Metadata {
      * ```
      *
      */
-    static getType = (target: any, propertyKey?: string | symbol): any =>
-        Reflect.getMetadata(DESIGN_TYPE, target, propertyKey!);
+    static getType(target: any, propertyKey?: string | symbol): any {
+        return Reflect.getMetadata(DESIGN_TYPE, target, propertyKey!);
+    }
+
+    /**
+     * Gets the metadata value for the provided metadata DESIGN_TYPE on the target object or its prototype chain.
+     * @param target The target object on which the metadata is defined.
+     * @param propertyKey The property key for the target.
+     * @returns The metadata value for the metadata key if found; otherwise, `undefined`.
+     * @example
+     *
+     * ```typescript
+     * class Example {
+     *     // property declarations are not part of ES6, though they are valid in TypeScript:
+     *     // static staticProperty;
+     *     // property;
+     *
+     *     static staticMethod(p) { }
+     *     method(p) { }
+     * }
+     *
+     * // on contructor
+     * result = Metadata.getOwnType(Example);
+     *
+     * // property (on constructor)
+     * result = Metadata.getOwnType(Example, "staticProperty");
+     *
+     * // method (on constructor)
+     * result = Metadata.getOwnType(Example, "staticMethod");
+     * ```
+     *
+     */
+    static getOwnType(target: any, propertyKey?: string | symbol): any {
+        return Reflect.getMetadata(DESIGN_TYPE, target, propertyKey!);
+    }
+
     /**
      * Gets the metadata value for the provided metadata DESIGN_RETURN_TYPE on the target object or its prototype chain.
      * @param target The target object on which the metadata is defined.
@@ -129,8 +179,42 @@ export class Metadata {
      * ```
      *
      */
-    static getReturnType = (target: any, propertyKey?: string | symbol): any =>
-        Reflect.getMetadata(DESIGN_RETURN_TYPE, target, propertyKey!);
+    static getReturnType(target: any, propertyKey?: string | symbol): any {
+        return Reflect.getMetadata(DESIGN_RETURN_TYPE, target, propertyKey!);
+    }
+
+    /**
+     * Gets the metadata value for the provided metadata DESIGN_RETURN_TYPE on the target object or its prototype chain.
+     * @param target The target object on which the metadata is defined.
+     * @param propertyKey The property key for the target.
+     * @returns The metadata value for the metadata key if found; otherwise, `undefined`.
+     * @example
+     *
+     * ```typescript
+     * class Example {
+     *     // property declarations are not part of ES6, though they are valid in TypeScript:
+     *     // static staticProperty;
+     *     // property;
+     *
+     *     static staticMethod(p) { }
+     *     method(p) { }
+     * }
+     *
+     * // on contructor
+     * result = Metadata.getOwnReturnType(Example);
+     *
+     * // property (on constructor)
+     * result = Metadata.getOwnReturnType(Example, "staticProperty");
+     *
+     * // method (on constructor)
+     * result = Metadata.getOwnReturnType(Example, "staticMethod");
+     * ```
+     *
+     */
+    static getOwnReturnType(target: any, propertyKey?: string | symbol): any {
+        return Reflect.getOwnMetadata(DESIGN_RETURN_TYPE, target, propertyKey!);
+    }
+
     /**
      * Gets a value indicating whether the target object or its prototype chain has the provided metadata key defined.
      * @param key A key used to store and retrieve metadata.
@@ -166,8 +250,49 @@ export class Metadata {
      * ```
      *
      */
-    static has = (key: string, target: any, propertyKey?: string | symbol): boolean =>
-        Reflect.hasMetadata(key, getClass(target), propertyKey!);
+    static has(key: string, target: any, propertyKey?: string | symbol): boolean {
+        return Reflect.hasMetadata(key, getClass(target), propertyKey!);
+    }
+
+    /**
+     * Gets a value indicating whether the target object or its prototype chain has the provided metadata key defined.
+     * @param key A key used to store and retrieve metadata.
+     * @param target The target object on which the metadata is defined.
+     * @param propertyKey The property key for the target.
+     * @returns `true` if the metadata key was defined on the target object or its prototype chain; otherwise, `false`.
+     * @example
+     *
+     * ```typescript
+     * class Example {
+     *     // property declarations are not part of ES6, though they are valid in TypeScript:
+     *     // static staticProperty;
+     *     // property;
+     *
+     *     static staticMethod(p) { }
+     *     method(p) { }
+     * }
+     *
+     * // constructor
+     * result = Metadata.has("custom:annotation", Example);
+     *
+     * // property (on constructor)
+     * result = Metadata.hasOwn("custom:annotation", Example, "staticProperty");
+     *
+     * // property (on prototype)
+     * result = Metadata.hasOwn("custom:annotation", Example.prototype, "property");
+     *
+     * // method (on constructor)
+     * result = Metadata.hasOwn("custom:annotation", Example, "staticMethod");
+     *
+     * // method (on prototype)
+     * result = Metadata.hasOwn("custom:annotation", Example.prototype, "method");
+     * ```
+     *
+     */
+    static hasOwn(key: string, target: any, propertyKey?: string | symbol): boolean {
+        return Reflect.hasOwnMetadata(key, getClass(target), propertyKey!);
+    }
+
     /**
      * Deletes the metadata entry from the target object with the provided key.
      * @param key A key used to store and retrieve metadata.
@@ -203,8 +328,9 @@ export class Metadata {
      * ```
      *
      */
-    static delete = (key: string, target: any, propertyKey?: string | symbol): boolean =>
-        Reflect.deleteMetadata(key, getClass(target), propertyKey!);
+    static delete(key: string, target: any, propertyKey?: string | symbol): boolean {
+        return Reflect.deleteMetadata(key, getClass(target), propertyKey!);
+    }
 
     /**
      * Set the metadata value for the provided metadata DESIGN_PARAM_TYPES on the target object or its prototype chain.
@@ -337,4 +463,61 @@ export class Metadata {
         return Reflect.getMetadata(DESIGN_PARAM_TYPES, target, propertyKey!) || [];
     }
 
+    /**
+     * Gets the metadata value for the provided metadata DESIGN_PARAM_TYPES on the target object or its prototype chain.
+     * @param target The target object on which the metadata is defined.
+     * @param propertyKey The property key for the target.
+     * @returns The metadata value for the metadata key if found; otherwise, `undefined`.
+     * @example
+     *
+     * ```typescript
+     * class Example {
+     *     // property declarations are not part of ES6, though they are valid in TypeScript:
+     *     // static staticProperty;
+     *     // property;
+     *
+     *     static staticMethod(p) { }
+     *     method(p) { }
+     * }
+     *
+     * // on contructor
+     * result = Metadata.getParamTypes(Example);
+     *
+     * // property (on constructor)
+     * result = Metadata.getParamTypes(Example, "staticProperty");
+     *
+     * // method (on constructor)
+     * result = Metadata.getParamTypes(Example, "staticMethod");
+     * ```
+     *
+     */
+    static getOwnParamTypes(target: any, propertyKey?: string | symbol): any[] {
+        return Reflect.getOwnMetadata(DESIGN_PARAM_TYPES, target, propertyKey!) || [];
+    }
 }
+
+/**
+ * Metadata key
+ * @private
+ * @type {string}
+ */
+const DESIGN_PARAM_TYPES = "design:paramtypes";
+/**
+ * Metadata key
+ * @private
+ * @type {string}
+ */
+const DESIGN_TYPE = "design:type";
+/**
+ * Metadata key
+ * @private
+ * @type {string}
+ */
+const DESIGN_RETURN_TYPE = "design:returntype";
+
+/**
+ * Properties collections
+ * @private
+ * @type {string}
+ */
+const PROPERTIES: Map<string | symbol, any[]> = new Map<string | symbol, any[]>();

--- a/src/core/class/Store.ts
+++ b/src/core/class/Store.ts
@@ -13,6 +13,7 @@ export const PROPERTY_STORE = "tsed:property:store";
 export const PARAM_STORE = "tsed:param:store";
 
 export type StoreMap = Map<string, any>;
+
 /**
  *
  */
@@ -49,6 +50,14 @@ export class Store {
     }
 
     /**
+     * Return the size of the collection.
+     * @returns {number}
+     */
+    get size() {
+        return this._map.size;
+    }
+
+    /**
      * Create or get a Store from args {target + methodName + descriptor}
      * @param args
      * @returns {Store}
@@ -58,28 +67,22 @@ export class Store {
     }
 
     /**
-     * Return the size of the collection.
-     * @returns {number}
-     */
-    get size() {
-        return this._map.size;
-    }
-
-    /**
      * The get() method returns a specified element from a Map object.
      * @param key Required. The key of the element to return from the Map object.
      * @returns {T} Returns the element associated with the specified key or undefined if the key can't be found in the Map object.
      */
-    get = <T>(key: any): any =>
-        this._map.get(nameOf(key));
+    get<T>(key: any): any {
+        return this._map.get(nameOf(key));
+    }
 
     /**
      * The has() method returns a boolean indicating whether an element with the specified key exists or not.
      * @param key
      * @returns {boolean}
      */
-    has = (key: any): boolean =>
-        this._map.has(nameOf(key));
+    has(key: any): boolean {
+        return this._map.has(nameOf(key));
+    }
 
     /**
      * The set() method adds or updates an element with a specified key and value to a Map object.
@@ -96,29 +99,33 @@ export class Store {
      * The entries() method returns a new Iterator object that contains the [key, value] pairs for each element in the Map object in insertion order.
      * @returns {IterableIterator} A new Map iterator object.
      */
-    entries = (): IterableIterator<[string, any]> =>
-        this._map.entries();
+    entries(): IterableIterator<[string, any]> {
+        return this._map.entries();
+    }
 
     /**
      * The keys() method returns a new Iterator object that contains the keys for each element in the Map object in insertion order.
      * @returns {IterableIterator} A new Map iterator object.
      */
-    keys = (): IterableIterator<string> =>
-        this._map.keys();
+    keys(): IterableIterator<string> {
+        return this._map.keys();
+    }
 
     /**
      * The clear() method removes all elements from a Map object.
      */
-    clear = () =>
-        this._map.clear();
+    clear() {
+        return this._map.clear();
+    }
 
     /**
      * The delete() method removes the specified element from a Map object.
      * @param key Required. The key of the element to remove from the Map object.
      * @returns {boolean} Returns true if an element in the Map object existed and has been removed, or false if the element does not exist.
      */
-    delete = (key: string): boolean =>
-        this._map.delete(nameOf(key));
+    delete(key: string): boolean {
+        return this._map.delete(nameOf(key));
+    }
 
     /**
      * The forEach() method executes a provided function once per each key/value pair in the Map object, in insertion order.
@@ -139,15 +146,17 @@ export class Store {
      * forEach executes the callback function once for each element in the Map object; it does not return a value.
      *
      */
-    forEach = (callbackfn: (value: any, key: string, map: Map<string, any>) => void, thisArg?: any): void =>
-        this._map.forEach(callbackfn);
+    forEach(callbackfn: (value: any, key: string, map: Map<string, any>) => void, thisArg?: any): void {
+        return this._map.forEach(callbackfn);
+    }
 
     /**
      * The values() method returns a new Iterator object that contains the values for each element in the Map object in insertion order.
      * @returns {IterableIterator} A new Map iterator object.
      */
-    values = (): IterableIterator<any> =>
-        this._map.values();
+    values(): IterableIterator<any> {
+        return this._map.values();
+    }
 
     /**
      *

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,6 +1,7 @@
 /**
  * @module common/core
- */ /** */
+ */
+/** */
 /**
  * Get the provide constructor.
  * @param targetClass
@@ -9,6 +10,7 @@ export const getContructor = (targetClass: any): Function =>
     typeof targetClass === "function"
         ? targetClass
         : targetClass.constructor;
+
 /**
  * Get the provide constructor if target is an instance.
  * @param target
@@ -47,6 +49,7 @@ export function isPrimitiveOrPrimitiveClass(target: any): boolean {
         || target instanceof Boolean
         || target === Boolean;
 }
+
 /**
  * Return true if the clazz is an array.
  * @param target
@@ -58,6 +61,7 @@ export function isArrayOrArrayClass(target: any): boolean {
     }
     return Object.prototype.toString.call(target) === "[object Array]";
 }
+
 /**
  * Return true if the target.
  * @param target
@@ -74,6 +78,7 @@ export function isCollection(target: any): boolean {
         || target === WeakSet
         || target instanceof WeakSet;
 }
+
 /**
  * Return true if the value is an empty string, null or undefined.
  * @param value
@@ -189,4 +194,8 @@ export function deepExtends(out: any, obj: any, reducers: { [key: string]: (coll
 
 export function isPromise(target: any): boolean {
     return target === Promise || target instanceof Promise;
+}
+
+export function getInhiritedClass(target: any): any {
+    return Object.getPrototypeOf(target);
 }

--- a/src/di/services/InjectorService.ts
+++ b/src/di/services/InjectorService.ts
@@ -166,6 +166,7 @@ export class InjectorService extends ProxyProviderRegistry {
             }
         }
 
+        /* istanbul ignore next */
         if (locals instanceof Map === false) {
             locals = new Map();
         }

--- a/src/filters/services/FilterService.ts
+++ b/src/filters/services/FilterService.ts
@@ -82,6 +82,7 @@ export class FilterService extends ProxyFilterRegistry {
 
         const provider = this.get(target);
 
+        /* istanbul ignore next */
         if (!provider) {
             throw new Error("Target component not found in the registry");
         }

--- a/src/mvc/class/ControllerBuilder.ts
+++ b/src/mvc/class/ControllerBuilder.ts
@@ -6,6 +6,7 @@ import * as Express from "express";
 import {Type} from "../../core/interfaces/Type";
 import {IRouterOptions} from "../interfaces";
 import {ControllerRegistry} from "../registries/ControllerRegistry";
+import {EndpointRegistry} from "../registries/EndpointRegistry";
 import {ControllerProvider} from "./ControllerProvider";
 
 import {EndpointBuilder} from "./EndpointBuilder";
@@ -13,7 +14,6 @@ import {EndpointBuilder} from "./EndpointBuilder";
 export class ControllerBuilder {
 
     constructor(private provider: ControllerProvider, private defaultRoutersOptions: IRouterOptions = {}) {
-        // console.log("Create controller =>", controller.provide.name);
         this.provider.router = Express.Router(Object.assign({}, defaultRoutersOptions, this.provider.routerOptions));
     }
 
@@ -24,14 +24,17 @@ export class ControllerBuilder {
     build(): this {
         const ctrl = this.provider;
 
-        ctrl.endpoints.map(endpoint =>
-            new EndpointBuilder(endpoint, this.provider.router).build()
-        );
+        EndpointRegistry.inherit(this.provider.useClass);
+
+        ctrl.endpoints.map(endpoint => {
+            new EndpointBuilder(endpoint, this.provider.router).build();
+        });
 
         ctrl.dependencies
             .forEach((child: Type<any>) => {
                 const ctrlMeta = ControllerRegistry.get(child);
 
+                /* istanbul ignore next */
                 if (!ctrlMeta) {
                     throw new Error("Controller component not found in the ControllerRegistry");
                 }

--- a/src/mvc/class/ControllerProvider.ts
+++ b/src/mvc/class/ControllerProvider.ts
@@ -81,7 +81,7 @@ export class ControllerProvider extends Provider<any> implements IControllerOpti
      * @returns {Endpoint[]}
      */
     get endpoints(): EndpointMetadata[] {
-        return EndpointRegistry.getByTarget(getClass(this.provide));
+        return EndpointRegistry.getEndpoints(getClass(this.provide));
     }
 
     /**

--- a/src/mvc/class/HandlerBuilder.ts
+++ b/src/mvc/class/HandlerBuilder.ts
@@ -67,6 +67,7 @@ export class HandlerBuilder {
     private middlewareHandler(): Function {
         const provider = MiddlewareRegistry.get(this.handlerMetadata.target);
 
+        /* istanbul ignore next */
         if (!provider) {
             throw new Error("Middleware component not found in the MiddlewareRegistry");
         }
@@ -83,6 +84,7 @@ export class HandlerBuilder {
 
         const provider = ControllerRegistry.get(this.handlerMetadata.target);
 
+        /* istanbul ignore next */
         if (!provider) {
             throw new Error("Controller component not found in the ControllerRegistry");
         }
@@ -128,7 +130,6 @@ export class HandlerBuilder {
 
         const {next, request, response} = locals;
         let nextCalled = false;
-        const tagId = request.tagId;
         const target = this.handlerMetadata.target;
         const injectable = this.handlerMetadata.injectable;
         const methodName = this.handlerMetadata.methodClassName;
@@ -156,7 +157,9 @@ export class HandlerBuilder {
         };
 
         try {
-            $log.debug(request.tagId, "[INVOKE][START]", info());
+            if (request.tagId) {
+                $log.debug(request.tagId, "[INVOKE][START]", info());
+            }
 
             const parameters = this.localsToParams(locals);
             const result = await (this.handler)(...parameters);

--- a/src/mvc/registries/EndpointRegistry.ts
+++ b/src/mvc/registries/EndpointRegistry.ts
@@ -5,42 +5,79 @@
 import {Metadata} from "../../core/class/Metadata";
 import {Store} from "../../core/class/Store";
 import {Type} from "../../core/interfaces/Type";
+import {getInhiritedClass} from "../../core/utils";
 import {EndpointMetadata} from "../class/EndpointMetadata";
 
 /**
  * Registry for all Endpoint collected on a provide.
  */
 export class EndpointRegistry {
+    /**
+     * Retrieve all endpoints from inherited class and store it in the registry.
+     * @param {Type<any>} ctrlClass
+     */
+    static inherit(ctrlClass: Type<any>) {
+        let inheritedClass = getInhiritedClass(ctrlClass);
 
-    static getByTarget(target: any): EndpointMetadata[] {
-        if (!Metadata.has(EndpointRegistry.name, target)) {
-            Metadata.set(EndpointRegistry.name, [], target);
+        while (inheritedClass && EndpointRegistry.hasEndpoints(inheritedClass)) {
+
+            this.getEndpoints(inheritedClass)
+                .forEach((endpointInheritedClass: EndpointMetadata) => {
+                    const endpoint = endpointInheritedClass.inherit(ctrlClass);
+
+                    EndpointRegistry
+                        .getEndpoints(ctrlClass)
+                        .push(endpoint);
+                });
+
+            inheritedClass = getInhiritedClass(inheritedClass);
         }
-        return Metadata.get(EndpointRegistry.name, target);
     }
 
     /**
-     *
+     * Get endpoints by his target.
+     * @param {Type<any>} target
+     * @returns {EndpointMetadata[]}
+     */
+    static getEndpoints(target: Type<any>): EndpointMetadata[] {
+        if (!this.hasEndpoints(target)) {
+            Metadata.set(EndpointRegistry.name, [], target);
+        }
+        return Metadata.getOwn(EndpointRegistry.name, target);
+    }
+
+    /**
+     * Gets a value indicating whether the target object or its prototype chain has endpoints.
+     * @param {Type<any>} target
+     * @returns {boolean}
+     */
+    static hasEndpoints(target: Type<any>) {
+        return Metadata.hasOwn(EndpointRegistry.name, target);
+    }
+
+    /**
+     * Get an endpoint.
      * @param target
      * @param method
      */
     static get(target: Type<any>, method: string): EndpointMetadata {
         if (!this.has(target, method)) {
             const endpoint = new EndpointMetadata(target, method);
-            EndpointRegistry.getByTarget(target).push(endpoint);
+            EndpointRegistry.getEndpoints(target).push(endpoint);
             Metadata.set(EndpointRegistry.name, endpoint, target, method);
         }
 
-        return Metadata.get(EndpointRegistry.name, target, method);
+        return Metadata.getOwn(EndpointRegistry.name, target, method);
     }
 
     /**
-     *
+     * Gets a value indicating whether the target object or its prototype chain has already method registered.
      * @param target
      * @param method
      */
-    static has = (target: Type<any>, method: string): boolean =>
-        Metadata.has(EndpointRegistry.name, target, method);
+    static has(target: Type<any>, method: string): boolean {
+        return Metadata.hasOwn(EndpointRegistry.name, target, method);
+    }
 
     /**
      * Append mvc in the pool (before).
@@ -78,8 +115,6 @@ export class EndpointRegistry {
 
     /**
      * Store a data on store manager.
-     * @param key
-     * @param value
      * @param targetClass
      * @param methodClassName
      * @returns {any}
@@ -95,10 +130,10 @@ export class EndpointRegistry {
      * @param targetClass
      * @param methodClassName
      */
-    static setMetadata = (key: any, value: any, targetClass: any, methodClassName: string) => {
+    static setMetadata(key: any, value: any, targetClass: any, methodClassName: string) {
         EndpointRegistry.store(targetClass, methodClassName).set(key, value);
         return EndpointRegistry;
-    };
+    }
 
     /**
      * Return the stored value for an endpoint method.
@@ -106,6 +141,7 @@ export class EndpointRegistry {
      * @param targetClass
      * @param methodClassName
      */
-    static getMetadata = (key: any, targetClass: any, methodClassName: string) =>
-        EndpointRegistry.store(targetClass, methodClassName).get(key);
+    static getMetadata(key: any, targetClass: any, methodClassName: string) {
+        return EndpointRegistry.store(targetClass, methodClassName).get(key);
+    }
 }

--- a/src/mvc/registries/ParamRegistry.ts
+++ b/src/mvc/registries/ParamRegistry.ts
@@ -61,7 +61,7 @@ export class ParamRegistry {
      * @param method
      */
     static isInjectable = (target: any, method: string): boolean =>
-    (Metadata.get(PARAM_METADATA, target, method) || []).length > 0;
+        (Metadata.get(PARAM_METADATA, target, method) || []).length > 0;
 
     /**
      *
@@ -143,7 +143,7 @@ export class ParamRegistry {
      * @param propertyKey
      */
     static hasNextFunction = (target: Type<any>, propertyKey: string) =>
-    ParamRegistry
-        .getParams(target, propertyKey)
-        .findIndex((p) => p.service === EXPRESS_NEXT_FN) > -1;
+        ParamRegistry
+            .getParams(target, propertyKey)
+            .findIndex((p) => p.service === EXPRESS_NEXT_FN) > -1;
 }

--- a/src/server/class/ServerSettingsProvider.ts
+++ b/src/server/class/ServerSettingsProvider.ts
@@ -253,6 +253,6 @@ export class ServerSettingsProvider implements IServerSettings {
      * @returns {any}
      */
     static getMetadata(target: any) {
-        return Metadata.get(SERVER_SETTINGS, target);
+        return Metadata.getOwn(SERVER_SETTINGS, target);
     }
 }

--- a/src/server/components/ServerLoader.ts
+++ b/src/server/components/ServerLoader.ts
@@ -238,6 +238,7 @@ export abstract class ServerLoader implements IServerLifecycle {
         InjectorService.factory(ServerSettingsService, this.settings.$get());
         return InjectorService.get<ServerSettingsService>(ServerSettingsService);
     }
+
     /**
      *
      * @param key
@@ -270,9 +271,11 @@ export abstract class ServerLoader implements IServerLifecycle {
             $log.info(`Started in ${new Date().getTime() - start.getTime()} ms`);
 
         } catch (err) {
-            return this.callHook("$onServerInitError", () => {
+            this.callHook("$onServerInitError", () => {
                 $log.error("HTTP Server error", err);
             }, err);
+
+            return Promise.reject(err);
         }
     }
 
@@ -286,7 +289,6 @@ export abstract class ServerLoader implements IServerLifecycle {
         const {address, port, https} = settings;
 
         $log.debug(`Start server on ${https ? "https" : "http"}://${settings.address}:${settings.port}`);
-
         const promise = new Promise((resolve, reject) => {
             http
                 .on("listening", resolve)
@@ -297,8 +299,6 @@ export abstract class ServerLoader implements IServerLifecycle {
             });
 
         http.listen(+port, address);
-
-
         return promise;
     }
 

--- a/test/integration/app/app.ts
+++ b/test/integration/app/app.ts
@@ -9,8 +9,8 @@ const rootDir = Path.resolve(__dirname);
 
 @ServerSettings({
     rootDir,
-    port: 8000,
-    httpsPort: 8080,
+    port: 8001,
+    httpsPort: 8081,
     mount: {
         "/rest": `${rootDir}/controllers/**/**.js`,
         "/rest/v1": `${rootDir}/controllers/**/**.js`

--- a/test/integration/app/controllers/base/BaseController.ts
+++ b/test/integration/app/controllers/base/BaseController.ts
@@ -1,0 +1,26 @@
+import {PathParams} from "../../../../../src/filters/decorators/pathParams";
+import {Get} from "../../../../../src/mvc/decorators/method/route";
+import {Description} from "../../../../../src/swagger/decorators/description";
+import {Summary} from "../../../../../src/swagger/decorators/summary";
+
+export class BaseController {
+
+    constructor(protected entriesService: any) {
+    }
+
+    @Get("/:resources/test/:id")
+    @Summary("Return an element by his resource")
+    async getTest(@Description("The resource")
+                  @PathParams("resources") resources: string,
+                  @Description("Id of the resource")
+                  @PathParams("id") id: string): Promise<any> {
+        return {_id: id};
+    }
+
+    @Get("/list")
+    @Summary("Return all elements from a service")
+    async index(): Promise<any[]> {
+
+        return [{_id: "test"}];
+    }
+}

--- a/test/integration/app/controllers/calendars/CalendarCtrl.ts
+++ b/test/integration/app/controllers/calendars/CalendarCtrl.ts
@@ -27,12 +27,14 @@ import {Description} from "../../../../../src/swagger/decorators/description";
 import {Security} from "../../../../../src/swagger/decorators/security";
 import {CalendarModel} from "../../models/Calendar";
 import {MongooseService} from "../../services/MongooseService";
+import {BaseController} from "../base/BaseController";
 import {EventCtrl} from "./EventCtrl";
 
 interface ICalendar {
     id: string;
     name: string;
 }
+
 /**
  * Add @ControllerProvider annotation to declare your provide as Router controller. The first param is the global path for your controller.
  * The others params is the controller dependencies.
@@ -40,12 +42,12 @@ interface ICalendar {
  * In this case, EventCtrl is a depedency of CalendarCtrl. All routes of EventCtrl will be mounted on the `/calendars` path.
  */
 @Controller("/calendars", EventCtrl)
-export class CalendarCtrl {
+export class CalendarCtrl extends BaseController {
 
     constructor(private mongooseService: MongooseService,
                 private routerController: RouterController) {
 
-        //
+        super(mongooseService);
         const router = this.routerController.getRouter();
 
     }

--- a/test/integration/app/controllers/calendars/EventCtrl.ts
+++ b/test/integration/app/controllers/calendars/EventCtrl.ts
@@ -5,6 +5,7 @@ import {Authenticated} from "../../../../../src/mvc/decorators/method/authentica
 import {Responses} from "../../../../../src/swagger/decorators/responses";
 import {Returns} from "../../../../../src/swagger/decorators/returns";
 import {EventModel} from "../../models/Event";
+import {BaseController} from "../base/BaseController";
 
 
 interface IEvent {
@@ -12,7 +13,7 @@ interface IEvent {
 }
 
 @Controller("/events")
-export class EventCtrl {
+export class EventCtrl extends BaseController {
     /**
      *
      */

--- a/test/integration/app/models/Event.ts
+++ b/test/integration/app/models/Event.ts
@@ -5,7 +5,7 @@ import {Title} from "../../../../src/swagger/decorators/title";
 
 export class Task {
     @JsonProperty()
-    public name: string | undefined = void 0;
+    public name: string = "";
 
     @JsonProperty()
     public percent: number;

--- a/test/integration/app/spec/swagger.json
+++ b/test/integration/app/spec/swagger.json
@@ -59,13 +59,26 @@
       "put": {
         "operationId": "EventCtrl.save_NaN",
         "tags": [
-          "EventCtrl"
+          "EventCtrl",
+          "CalendarCtrl"
         ],
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model1"
+            }
+          }
+        ],
         "consumes": [],
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad request"
           }
         },
         "produces": [],
@@ -84,6 +97,46 @@
           }
         },
         "produces": [],
+        "deprecated": false
+      },
+      "delete": {
+        "operationId": "CalendarCtrl.remove_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model1"
+            }
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "400": {
+            "description": "Bad request"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "produces": [],
+        "security": [
+          {
+            "calendar_auth": [
+              "write:calendar",
+              "read:calendar"
+            ]
+          },
+          {
+            "global_auth": [
+              "read:global"
+            ]
+          }
+        ],
         "deprecated": false
       }
     },
@@ -111,6 +164,9 @@
         ],
         "consumes": [],
         "responses": {
+          "400": {
+            "description": "Bad request"
+          },
           "404": {
             "description": "Not found"
           }
@@ -309,6 +365,9 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad request"
           }
         },
         "produces": [],
@@ -390,7 +449,8 @@
       "put": {
         "operationId": "CalendarCtrl.save_NaN",
         "tags": [
-          "CalendarCtrl"
+          "CalendarCtrl",
+          "EventCtrl"
         ],
         "parameters": [
           {
@@ -406,6 +466,9 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad request"
           }
         },
         "produces": [],
@@ -428,6 +491,9 @@
         ],
         "consumes": [],
         "responses": {
+          "400": {
+            "description": "Bad request"
+          },
           "403": {
             "description": "Forbidden"
           }
@@ -446,6 +512,36 @@
             ]
           }
         ],
+        "deprecated": false
+      },
+      "head": {
+        "operationId": "EventCtrl.head",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      },
+      "get": {
+        "operationId": "EventCtrl.query",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
         "deprecated": false
       }
     },
@@ -553,13 +649,26 @@
       "put": {
         "operationId": "EventCtrl.save",
         "tags": [
-          "EventCtrl"
+          "EventCtrl",
+          "CalendarCtrl"
         ],
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model1"
+            }
+          }
+        ],
         "consumes": [],
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad request"
           }
         },
         "produces": [],
@@ -578,6 +687,46 @@
           }
         },
         "produces": [],
+        "deprecated": false
+      },
+      "delete": {
+        "operationId": "CalendarCtrl.remove",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model1"
+            }
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "400": {
+            "description": "Bad request"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "produces": [],
+        "security": [
+          {
+            "calendar_auth": [
+              "write:calendar",
+              "read:calendar"
+            ]
+          },
+          {
+            "global_auth": [
+              "read:global"
+            ]
+          }
+        ],
         "deprecated": false
       }
     },
@@ -605,6 +754,9 @@
         ],
         "consumes": [],
         "responses": {
+          "400": {
+            "description": "Bad request"
+          },
           "404": {
             "description": "Not found"
           }
@@ -797,6 +949,9 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad request"
           }
         },
         "produces": [],
@@ -878,7 +1033,8 @@
       "put": {
         "operationId": "CalendarCtrl.save",
         "tags": [
-          "CalendarCtrl"
+          "CalendarCtrl",
+          "EventCtrl"
         ],
         "parameters": [
           {
@@ -894,6 +1050,9 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Bad request"
           }
         },
         "produces": [],
@@ -916,6 +1075,9 @@
         ],
         "consumes": [],
         "responses": {
+          "400": {
+            "description": "Bad request"
+          },
           "403": {
             "description": "Forbidden"
           }
@@ -934,6 +1096,36 @@
             ]
           }
         ],
+        "deprecated": false
+      },
+      "head": {
+        "operationId": "EventCtrl.head",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      },
+      "get": {
+        "operationId": "EventCtrl.query",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
         "deprecated": false
       }
     },
@@ -1054,6 +1246,978 @@
         },
         "produces": [],
         "deprecated": false
+      }
+    },
+    "/rest/calendars/events/list": {
+      "get": {
+        "operationId": "EventCtrl.index_NaN",
+        "tags": [
+          "BaseController",
+          "EventCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false,
+        "summary": "Return all elements from a service"
+      }
+    },
+    "/rest/calendars/events/classic/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.findClassic_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/token": {
+      "get": {
+        "operationId": "CalendarCtrl.getToken_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/token/{token}": {
+      "get": {
+        "operationId": "CalendarCtrl.updateToken_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "token",
+            "type": "string",
+            "required": true,
+            "description": "Token required to update token"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/annotation/test/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.findWithAnnotation_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "400": {
+            "description": "Bad request"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/annotation/promised/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.findWithPromise_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/annotation/status/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.findAndChangeStatusCode_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/query": {
+      "get": {
+        "operationId": "CalendarCtrl.getQuery_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "name": "search",
+            "type": "string",
+            "in": "query"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/middleware": {
+      "get": {
+        "operationId": "CalendarCtrl.getWithMiddleware_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "name": "authorization",
+            "type": "string",
+            "in": "header"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/mvc": {
+      "get": {
+        "operationId": "CalendarCtrl.testStackMiddlewares_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/middlewares2": {
+      "get": {
+        "operationId": "CalendarCtrl.testUseAfter_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/headers": {
+      "get": {
+        "operationId": "CalendarCtrl.testResponseHeader_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": true
+      }
+    },
+    "/rest/calendars/events/documents": {
+      "post": {
+        "operationId": "CalendarCtrl.testMultipart_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/documents/1": {
+      "post": {
+        "operationId": "CalendarCtrl.testMultipart2_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/list": {
+      "get": {
+        "operationId": "CalendarCtrl.index_NaN",
+        "tags": [
+          "BaseController",
+          "EventCtrl",
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false,
+        "summary": "Return all elements from a service"
+      }
+    },
+    "/rest/calendars/{id}": {
+      "patch": {
+        "operationId": "EventCtrl.patch",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventModel"
+            }
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      },
+      "get": {
+        "operationId": "EventCtrl.find",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      },
+      "post": {
+        "operationId": "EventCtrl.update",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Model1"
+            }
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      },
+      "delete": {
+        "operationId": "EventCtrl.remove",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/list": {
+      "get": {
+        "operationId": "EventCtrl.index",
+        "tags": [
+          "BaseController",
+          "EventCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false,
+        "summary": "Return all elements from a service"
+      }
+    },
+    "/rest/v1/calendars/events/classic/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.findClassic",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/token": {
+      "get": {
+        "operationId": "CalendarCtrl.getToken",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/token/{token}": {
+      "get": {
+        "operationId": "CalendarCtrl.updateToken",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "token",
+            "type": "string",
+            "required": true,
+            "description": "Token required to update token"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/annotation/test/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.findWithAnnotation",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "400": {
+            "description": "Bad request"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/annotation/promised/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.findWithPromise",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/annotation/status/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.findAndChangeStatusCode",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/query": {
+      "get": {
+        "operationId": "CalendarCtrl.getQuery",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "name": "search",
+            "type": "string",
+            "in": "query"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/middleware": {
+      "get": {
+        "operationId": "CalendarCtrl.getWithMiddleware",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "name": "authorization",
+            "type": "string",
+            "in": "header"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/mvc": {
+      "get": {
+        "operationId": "CalendarCtrl.testStackMiddlewares",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/middlewares2": {
+      "get": {
+        "operationId": "CalendarCtrl.testUseAfter",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/headers": {
+      "get": {
+        "operationId": "CalendarCtrl.testResponseHeader",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": true
+      }
+    },
+    "/rest/v1/calendars/events/documents": {
+      "post": {
+        "operationId": "CalendarCtrl.testMultipart",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/events/documents/1": {
+      "post": {
+        "operationId": "CalendarCtrl.testMultipart2",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/v1/calendars/list": {
+      "get": {
+        "operationId": "CalendarCtrl.index",
+        "tags": [
+          "BaseController",
+          "EventCtrl",
+          "CalendarCtrl"
+        ],
+        "parameters": [],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false,
+        "summary": "Return all elements from a service"
+      }
+    },
+    "/rest/v1/calendars/{id}": {
+      "patch": {
+        "operationId": "EventCtrl.patch",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EventModel"
+            }
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      },
+      "get": {
+        "operationId": "EventCtrl.find",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      },
+      "post": {
+        "operationId": "EventCtrl.update",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          },
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Model1"
+            }
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      },
+      "delete": {
+        "operationId": "EventCtrl.remove",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false
+      }
+    },
+    "/rest/calendars/events/{resources}/test/{id}": {
+      "get": {
+        "operationId": "EventCtrl.getTest_NaN",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resources",
+            "type": "string",
+            "required": true,
+            "description": "The resource"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true,
+            "description": "Id of the resource"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false,
+        "summary": "Return an element by his resource"
+      }
+    },
+    "/rest/calendars/{resources}/test/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.getTest_NaN",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resources",
+            "type": "string",
+            "required": true,
+            "description": "The resource"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true,
+            "description": "Id of the resource"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false,
+        "summary": "Return an element by his resource"
+      }
+    },
+    "/rest/v1/calendars/events/{resources}/test/{id}": {
+      "get": {
+        "operationId": "EventCtrl.getTest",
+        "tags": [
+          "EventCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resources",
+            "type": "string",
+            "required": true,
+            "description": "The resource"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true,
+            "description": "Id of the resource"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false,
+        "summary": "Return an element by his resource"
+      }
+    },
+    "/rest/v1/calendars/{resources}/test/{id}": {
+      "get": {
+        "operationId": "CalendarCtrl.getTest",
+        "tags": [
+          "CalendarCtrl"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "resources",
+            "type": "string",
+            "required": true,
+            "description": "The resource"
+          },
+          {
+            "in": "path",
+            "name": "id",
+            "type": "string",
+            "required": true,
+            "description": "Id of the resource"
+          }
+        ],
+        "consumes": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        },
+        "produces": [],
+        "deprecated": false,
+        "summary": "Return an element by his resource"
       }
     }
   },

--- a/test/units/core/class/Metadata.spec.ts
+++ b/test/units/core/class/Metadata.spec.ts
@@ -71,6 +71,16 @@ describe("Metadata", () => {
         });
     });
 
+    describe("getOwn", () => {
+        it("should get meta on a class", () => {
+            expect(Metadata.getOwn("metadatakey1", Test)).to.equal("test1");
+        });
+
+        it("should get meta on a method", () => {
+            expect(Metadata.getOwn("metadatakey3", Test, "method")).to.equal("test1");
+        });
+    });
+
     describe("delete", () => {
         it("should remove meta on a class", () => {
             expect(Metadata.delete("metadatakey1", Test)).to.equal(true);
@@ -80,6 +90,12 @@ describe("Metadata", () => {
     describe("getType", () => {
         it("should return attribut type", () => {
             expect(Metadata.getType(Test.prototype, "attribut")).to.equal(String);
+        });
+    });
+
+    describe("getOwnType", () => {
+        it("should return attribut type", () => {
+            expect(Metadata.getOwnType(Test.prototype, "attribut")).to.equal(String);
         });
     });
 
@@ -95,9 +111,27 @@ describe("Metadata", () => {
         });
     });
 
+    describe("getOwnParamTypes", () => {
+        it("should return types on constructor", () => {
+            expect(Metadata.getOwnParamTypes(Test)).to.be.an("array");
+            expect(Metadata.getOwnParamTypes(Test)[0]).to.equal(String);
+        });
+
+        it("should return types on method", () => {
+            expect(Metadata.getOwnParamTypes(Test.prototype, "method")).to.be.an("array");
+            expect(Metadata.getOwnParamTypes(Test.prototype, "method")[0]).to.equal(String);
+        });
+    });
+
     describe("getReturnType", () => {
         it("should return types on method", () => {
             expect(Metadata.getReturnType(Test.prototype, "method")).to.equal(Boolean);
+        });
+    });
+
+    describe("getOwnReturnType", () => {
+        it("should return types on method", () => {
+            expect(Metadata.getOwnReturnType(Test.prototype, "method")).to.equal(Boolean);
         });
     });
 

--- a/test/units/core/class/Registry.spec.ts
+++ b/test/units/core/class/Registry.spec.ts
@@ -6,7 +6,6 @@ class FakeMetadata {
     attr2: any;
 
     constructor(public target: any) {
-        console.log(target);
     }
 
     test() {

--- a/test/units/mvc/class/EndpointBuilder.spec.ts
+++ b/test/units/mvc/class/EndpointBuilder.spec.ts
@@ -1,11 +1,11 @@
 import * as Express from "express";
 import * as Proxyquire from "proxyquire";
-import {expect, Sinon} from "../../../tools";
 
 import {EndpointMetadata} from "../../../../src/mvc/class/EndpointMetadata";
 import {inject} from "../../../../src/testing/inject";
 import {FakeRequest} from "../../../helper/FakeRequest";
 import {FakeResponse} from "../../../helper/FakeResponse";
+import {expect, Sinon} from "../../../tools";
 
 
 const HandlerBuilder = {

--- a/test/units/mvc/class/EndpointMetadata.spec.ts
+++ b/test/units/mvc/class/EndpointMetadata.spec.ts
@@ -1,74 +1,163 @@
-import {assert, expect} from "chai";
-import {EndpointMetadata} from "../../../../src/mvc/class/EndpointMetadata";
+import {expect} from "chai";
 import {Metadata} from "../../../../src/core/class/Metadata";
+import {EndpointMetadata} from "../../../../src/mvc/class/EndpointMetadata";
 import {EndpointRegistry} from "../../../../src/mvc/registries/EndpointRegistry";
 
 class Test {
 
 }
+
 class Test2 {
+
+}
+
+class Test3 extends Test2 {
+
 }
 
 describe("EndpointMetadata", () => {
+    describe("Basic class", () => {
+        before(() => {
+            this.endpointMetadata = new EndpointMetadata(Test, "method");
 
-    before(() => {
-        this.endpointMetadata = new EndpointMetadata(Test, "method");
+            this.endpointMetadata.path = "/";
+            this.endpointMetadata.httpMethod = "get";
+            this.endpointMetadata.beforeMiddlewares = [() => {
+            }];
+            this.endpointMetadata.middlewares = [() => {
+            }];
+            this.endpointMetadata.afterMiddlewares = [() => {
+            }];
+            this.endpointMetadata.before([() => {
+            }]);
+            this.endpointMetadata.after([() => {
+            }]);
 
-        this.endpointMetadata.path = "/";
-        this.endpointMetadata.httpMethod = "get";
-        this.endpointMetadata.beforeMiddlewares = [() => {
-        }];
-        this.endpointMetadata.middlewares = [() => {
-        }];
-        this.endpointMetadata.afterMiddlewares = [() => {
-        }];
-        this.endpointMetadata.before([() => {
-        }]);
-        this.endpointMetadata.after([() => {
-        }]);
+            EndpointRegistry.store(Test, "method").set("test", "value");
 
-        EndpointRegistry.store(Test, "method").set("test", "value");
+            Metadata.set("design:returntype", Object, Test, "method");
 
-        Metadata.set("design:returntype", Object, Test, "method");
+            this.store = {};
+            this.endpointMetadata.store.forEach((v: any, k: any) => this.store[k] = v);
+        });
+
+        it("should get path", () =>
+            expect(this.endpointMetadata.path).to.equal("/")
+        );
+
+        it("should get httpMethod", () =>
+            expect(this.endpointMetadata.httpMethod).to.equal("get")
+        );
+
+        it("should get path", () =>
+            expect(this.endpointMetadata.path).to.equal("/")
+        );
+
+        it("should get beforeMiddlewares", () => {
+            expect(this.endpointMetadata.beforeMiddlewares).to.be.an("array").and.have.length(2);
+        });
+
+        it("should get middlewares", () => {
+            expect(this.endpointMetadata.middlewares).to.be.an("array").and.have.length(1);
+        });
+
+        it("should get afterMiddlewares", () => {
+            expect(this.endpointMetadata.beforeMiddlewares).to.be.an("array").and.have.length(2);
+        });
+
+        it("should has method", () => {
+            expect(this.endpointMetadata.hasHttpMethod()).to.be.true;
+        });
+
+        it("should get target", () =>
+            expect(this.endpointMetadata.target).to.equal(Test)
+        );
+
+        it("should get methodClassName", () =>
+            expect(this.endpointMetadata.methodClassName).to.equal("method")
+        );
+
+        it("should get metadata", () =>
+            expect(this.endpointMetadata.getMetadata("test")).to.equal("value")
+        );
+
+        it("should return the store", () => {
+            expect(this.store).to.deep.equal({"test": "value"});
+        });
     });
 
-    it("should get path", () =>
-        expect(this.endpointMetadata.path).to.equal("/")
-    );
+    describe("Inherited class", () => {
+        before(() => {
+            this.endpointMetadata = new EndpointMetadata(Test2, "methodInherited");
+            this.endpointMetadata.path = "/";
+            this.endpointMetadata.httpMethod = "get";
+            this.endpointMetadata.beforeMiddlewares = [() => {
+            }];
+            this.endpointMetadata.middlewares = [() => {
+            }];
+            this.endpointMetadata.afterMiddlewares = [() => {
+            }];
+            this.endpointMetadata.before([() => {
+            }]);
+            this.endpointMetadata.after([() => {
+            }]);
 
-    it("should get httpMethod", () =>
-        expect(this.endpointMetadata.httpMethod).to.equal("get")
-    );
+            EndpointRegistry.store(Test2, "methodInherited").set("test2", "value2");
 
-    it("should get path", () =>
-        expect(this.endpointMetadata.path).to.equal("/")
-    );
+            Metadata.set("design:returntype", Object, Test2, "methodInherited");
 
-    it("should get beforeMiddlewares", () => {
-        expect(this.endpointMetadata.beforeMiddlewares).to.be.an("array").and.have.length(2);
+            this.endpointMetadataInherited = this.endpointMetadata.inherit(Test3);
+
+            this.store = {};
+            this.endpointMetadataInherited.store.forEach((v: any, k: any) => this.store[k] = v);
+        });
+
+        it("should get path", () =>
+            expect(this.endpointMetadataInherited.path).to.equal("/")
+        );
+
+        it("should get httpMethod", () =>
+            expect(this.endpointMetadataInherited.httpMethod).to.equal("get")
+        );
+
+        it("should get path", () =>
+            expect(this.endpointMetadataInherited.path).to.equal("/")
+        );
+
+        it("should get beforeMiddlewares", () => {
+            expect(this.endpointMetadataInherited.beforeMiddlewares).to.be.an("array").and.have.length(2);
+        });
+
+        it("should get middlewares", () => {
+            expect(this.endpointMetadataInherited.middlewares).to.be.an("array").and.have.length(1);
+        });
+
+        it("should get afterMiddlewares", () => {
+            expect(this.endpointMetadataInherited.beforeMiddlewares).to.be.an("array").and.have.length(2);
+        });
+
+        it("should has method", () => {
+            expect(this.endpointMetadataInherited.hasHttpMethod()).to.be.true;
+        });
+
+        it("should get target", () =>
+            expect(this.endpointMetadataInherited.target).to.equal(Test3)
+        );
+
+        it("should have a inherited metadata", () =>
+            expect(this.endpointMetadataInherited.inheritedEndpoint.target).to.equal(Test2)
+        );
+
+        it("should get methodClassName", () =>
+            expect(this.endpointMetadata.methodClassName).to.equal("methodInherited")
+        );
+
+        it("should get metadata", () =>
+            expect(this.endpointMetadata.getMetadata("test2")).to.equal("value2")
+        );
+
+        it("should return the store", () => {
+            expect(this.store).to.deep.equal({"test2": "value2"});
+        });
     });
-
-    it("should get middlewares", () => {
-        expect(this.endpointMetadata.middlewares).to.be.an("array").and.have.length(1);
-    });
-
-    it("should get afterMiddlewares", () => {
-        expect(this.endpointMetadata.beforeMiddlewares).to.be.an("array").and.have.length(2);
-    });
-
-    it("should has method", () => {
-        expect(this.endpointMetadata.hasHttpMethod()).to.be.true;
-    });
-
-    it("should get target", () =>
-        expect(this.endpointMetadata.target).to.equal(Test)
-    );
-
-    it("should get methodClassName", () =>
-        expect(this.endpointMetadata.methodClassName).to.equal("method")
-    );
-
-    it("should get metadata", () =>
-        expect(this.endpointMetadata.getMetadata("test")).to.equal("value")
-    );
 });

--- a/test/units/mvc/registries/ParamsRegistry.spec.ts
+++ b/test/units/mvc/registries/ParamsRegistry.spec.ts
@@ -1,6 +1,6 @@
-import {expect, Sinon} from "../../../tools";
 import * as Proxyquire from "proxyquire";
 import {EXPRESS_NEXT_FN} from "../../../../src/mvc/constants/index";
+import {expect, Sinon} from "../../../tools";
 
 class Test {
 

--- a/test/units/server/components/ServerLoader.spec.ts
+++ b/test/units/server/components/ServerLoader.spec.ts
@@ -1,4 +1,7 @@
 import {Metadata} from "../../../../src/core/class/Metadata";
+import {HttpServer} from "../../../../src/core/services/HttpServer";
+import {HttpsServer} from "../../../../src/core/services/HttpsServer";
+import {InjectorService} from "../../../../src/di/services/InjectorService";
 import {ServerLoader} from "../../../../src/server/components/ServerLoader";
 import {SERVER_SETTINGS} from "../../../../src/server/constants/index";
 import {$logStub, expect, Sinon} from "../../../tools";
@@ -32,12 +35,21 @@ describe("ServerLoader", () => {
         this.setStub = Sinon.stub(this.server._expressApp, "set");
         this.engineStub = Sinon.stub(this.server._expressApp, "engine");
 
+        this.httpServer = InjectorService.get<HttpServer>(HttpServer).get();
+        this.httpsServer = InjectorService.get<HttpsServer>(HttpsServer).get();
     });
 
     after(() => {
         this.useStub.restore();
         this.setStub.restore();
         this.engineStub.restore();
+    });
+
+    it("should add the httpServer in injectorService", () => {
+        this.httpServer.should.be.an("object");
+    });
+    it("should add the httpsServer in injectorService", () => {
+        this.httpsServer.should.be.an("object");
     });
 
     describe("startServer()", () => {
@@ -196,7 +208,8 @@ describe("ServerLoader", () => {
 
                 $logStub.$log.error.reset();
 
-                return this.server.start();
+                return this.server.start().catch((err: any) => {
+                });
             });
 
             after(() => {

--- a/test/units/testing/bootstrap.spec.ts
+++ b/test/units/testing/bootstrap.spec.ts
@@ -12,8 +12,6 @@ class FakeServer {
 }
 
 describe("bootstrap", () => {
-
-
     it("should mock server for test", (done) => {
 
         const fnMocha = bootstrap(FakeServer);


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Status | Migration
---|---|---
Fix & Documentation | Ready | No

****

## Description
- Fix EndpointBuilder, ControllerBuilder, ControllerProvider
- Add method Metadata.getOwn(), Metadata.hasOwn
- Fix ServerLoader error

Closes: #91

## Usage example
Ts.ED support the ES6 inheritance class. So you can declare a controller that implement some generic method
and use it on a children class.


To do that just declare a parent controller without the `@Controller` decorator.
```typescript
export abstract class BaseController {
    constructor(private someService: SomeService) {}
    
    @Get('/list')
    async list(@QueryParams("search") search: any) {
        return someService.list(search)
    }
}
```

Then, on your children controller:

```typescript
@Controller('/children')
export abstract class ChildrenCtrl extends BaseController {
    @Get('/:id')
    async get(@PathParams("id") id: string): Promise<any> {
      return {id: id}  
    }
}
```
## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation