### PR TITLE
feat(server): Allow multiple path for each mounting endpoint

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,10 @@ import Path = require("path");
    rootDir: Path.resolve(__dirname), //optional. By default it's equal to process.cwd()
    mount: {
      "/rest": "${rootDir}/controllers/current/**/*.js",
-     "/rest/v1": "${rootDir}/controllers/v1/**/*.js"
+     "/rest/v1": [
+        "${rootDir}/controllers/v1/users/*.js", 
+        "${rootDir}/controllers/v1/groups/*.js"
+     ]
    }
 })
 export class Server extends ServerLoader {
@@ -61,9 +64,9 @@ new Server.start();
   * `cert` &lt;string&gt; | &lt;string[]&gt; | [&lt;Buffer&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer) | [&lt;Buffer[]&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer): A string, Buffer, array of strings, or array of Buffers containing the certificate key of the server in PEM format. (Required)
   * `ca` &lt;string&gt; | &lt;string[]&gt; | [&lt;Buffer&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer) | [&lt;Buffer[]&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer): A string, Buffer, array of strings, or array of Buffers of trusted certificates in PEM format. If this is omitted several well known "root" CAs (like VeriSign) will be used. These are used to authorize connections.
 * `uploadDir` &lt;string&gt: The temporary directory to upload the documents. See more on [Upload file with Multer](tutorials/upload-files-with-multer.md).
-* `mount` &lt;IServerMountDirectories&gt;: Mount all controllers under a directories to an endpoint.
+* `mount` &lt;[IServerMountDirectories](api/common/server/iservermountdirectories.md)&gt;: Mount all controllers under a directories to an endpoint.
 * `componentsScan` &lt;string[]&gt;: List of directories to scan [Services](docs/services/overview.md), [Middlewares](docs/middlewares/overview.md) or [Converters](docs/converters.md).
-* `serveStatic` &lt;IServerMountDirectories&gt;: Object to mount all directories under to his endpoints. See more on [Serve Static](tutorials/serve-static-files.md).
+* `serveStatic` &lt;[IServerMountDirectories](api/common/server/iservermountdirectories.md)&gt;: Object to mount all directories under to his endpoints. See more on [Serve Static](tutorials/serve-static-files.md).
 * `swagger` &lt;Object&gt;: Object configure swagger. See more on [Swagger](tutorials/swagger.md).
 * `debug` &lt;boolean&gt;: Enable debug mode. By default debug is false.
 * `routers` &lt;object&gt;: Global configuration for the Express.Router. See express [documentation](http://expressjs.com/en/api.html#express.router).

--- a/docs/docs/server-loader/versioning.md
+++ b/docs/docs/server-loader/versioning.md
@@ -4,6 +4,7 @@ Ts.ED provide the possibility to mount multiple Rest path instead of the default
 You have two methods to configure all global endpoints for each directories scanned by the [ServerLoader](api/common/server/serverloader.md).
 
 ### With decorator (Recommended)
+
 ```typescript
 import {ServerLoader, ServerSettings} from "ts-express-decorators";
 import Path = require("path");
@@ -13,7 +14,10 @@ const rootDir = Path.resolve(__dirname);
    rootDir,
    mount: {
      "/rest": "${rootDir}/controllers/current/**/*.js",
-     "/rest/v1": "${rootDir}/controllers/v1/**/*.js"
+     "/rest/v1": [
+        "${rootDir}/controllers/v1/users/*.js", 
+        "${rootDir}/controllers/v1/groups/*.js"
+     ]
    }
 })
 export class Server extends ServerLoader {
@@ -22,6 +26,7 @@ export class Server extends ServerLoader {
 
 new Server().start();
 ```
+> Note: mount attribute accept a list of glob for each endpoint. That let you to declare a resource versioning.
 
 ### With ServerLoader API
 
@@ -37,7 +42,10 @@ export class Server extends ServerLoader implements IServerLifecycle {
         const appPath: string = Path.resolve(__dirname);
 
         this.mount('rest/', appPath + "/controllers/**/**.js") 
-            .mount('rest/v1/', appPath + "/v1/controllers/**/**.js") 
+            .mount('rest/v1/', [
+                appPath + "/controllers/v1/users/**.js",
+                appPath + "/controllers/v1/groups/**.js"
+            ]) 
             .createHttpServer(8000)
             .createHttpsServer({
                 port: 8080

--- a/src/server/components/ServerLoader.ts
+++ b/src/server/components/ServerLoader.ts
@@ -449,9 +449,11 @@ export abstract class ServerLoader implements IServerLifecycle {
      * @param path
      * @returns {ServerLoader}
      */
-    public mount(endpoint: string, path: string): ServerLoader {
+    public mount(endpoint: string, path: string | string[]): ServerLoader {
 
-        this.scan(path, endpoint);
+        [].concat(path as any).forEach((path: string) => {
+            this.scan(path, endpoint);
+        });
 
         return this;
     }

--- a/src/server/decorators/serverSettings.ts
+++ b/src/server/decorators/serverSettings.ts
@@ -1,11 +1,13 @@
 /**
  * @module common/server
- */ /** */
+ */
+/** */
 
 import {Metadata} from "../../core/class/Metadata";
 import {Type} from "../../core/interfaces/Type";
 import {SERVER_SETTINGS} from "../constants/index";
 import {IServerSettings} from "../interfaces/IServerSettings";
+
 /**
  * `@ServerSettings` let you to configure quickly your server via decorator. This decorator take your configuration and merge it with the default server configuration.
  *
@@ -38,7 +40,10 @@ import {IServerSettings} from "../interfaces/IServerSettings";
  *     rootDir: Path.resolve(__dirname),
  *     mount: {
  *         "/rest": "${rootDir}/controllers/current/**\/*.js",
- *         "/rest/v1": "${rootDir}/controllers/v1/**\/*.js"
+ *         "/rest/v1": [
+ *           "${rootDir}/controllers/v1/users/*.js",
+ *           "${rootDir}/controllers/v1/groups/*.js"
+ *         ]
  *     }
  * })
  * export class Server extends ServerLoader {
@@ -59,9 +64,9 @@ import {IServerSettings} from "../interfaces/IServerSettings";
  *   * `cert` &lt;string&gt; | &lt;string[]&gt; | [&lt;Buffer&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer) | [&lt;Buffer[]&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer): A string, Buffer, array of strings, or array of Buffers containing the certificate key of the server in PEM format. (Required)
  *   * `ca` &lt;string&gt; | &lt;string[]&gt; | [&lt;Buffer&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer) | [&lt;Buffer[]&gt;](https://nodejs.org/api/buffer.html#buffer_class_buffer): A string, Buffer, array of strings, or array of Buffers of trusted certificates in PEM format. If this is omitted several well known "root" CAs (like VeriSign) will be used. These are used to authorize connections.
  * * `uploadDir` &lt;string&gt: The temporary directory to upload the documents. See more on [Upload file with Multer](tutorials/upload-files-with-multer.md).
- * * `mount` &lt;IServerMountDirectories&gt;: Mount all controllers under a directories to an endpoint.
+ * * `mount` &lt;[IServerMountDirectories](api/common/server/iservermountdirectories.md)&gt;: Mount all controllers under a directories to an endpoint.
  * * `componentsScan` &lt;string[]&gt;: List of directories to scan [Services](docs/services/ovierview.md), [Middlewares](docs/middlewares/ovierview.md) or [Converters](docs/converters.md).
- * * `serveStatic` &lt;IServerMountDirectories&gt;: Objet to mount all directories under to his endpoints. See more on [Serve Static](tutorials/serve-static-files.md).
+ * * `serveStatic` &lt;[IServerMountDirectories](api/common/server/iservermountdirectories.md)&gt;: Objet to mount all directories under to his endpoints. See more on [Serve Static](tutorials/serve-static-files.md).
  * * `routers` &lt;object&gt;: Global configuration for the Express.Router. See express [documentation](http://expressjs.com/en/api.html#express.router).
  *
  * @param settings

--- a/src/server/interfaces/IServerSettings.ts
+++ b/src/server/interfaces/IServerSettings.ts
@@ -1,17 +1,21 @@
 /**
  * @module common/server
- */ /** */
+ */
+/** */
 
 import * as Https from "https";
 
 import {Env} from "../../core/interfaces/Env";
 
 export interface IServerMountDirectories {
-    [endpoint: string]: string;
+    [endpoint: string]: string | string[];
 }
 
 export interface IServerSettings {
     rootDir?: string;
+    /**
+     * @deprecated
+     */
     endpointUrl?: string;
     env?: Env;
     port?: string | number;
@@ -24,5 +28,6 @@ export interface IServerSettings {
     serveStatic?: IServerMountDirectories;
     acceptMimes?: string[];
     debug?: boolean;
+
     [key: string]: any;
 }

--- a/src/servestatic/services/ServeStaticService.ts
+++ b/src/servestatic/services/ServeStaticService.ts
@@ -20,7 +20,11 @@ export class ServeStaticService {
         if (require.resolve("serve-static")) {
             Object
                 .keys(this.serverSettingsService.serveStatic)
-                .forEach(path => this.mount(path));
+                .forEach(path => {
+                    []
+                        .concat(path as any)
+                        .forEach((path: string) => this.mount(path));
+                });
 
         }
     }

--- a/test/units/server/components/ServerLoader.spec.ts
+++ b/test/units/server/components/ServerLoader.spec.ts
@@ -145,6 +145,45 @@ describe("ServerLoader", () => {
 
     });
 
+    describe("mount()", () => {
+        describe("when we give a single path", () => {
+            before(() => {
+                this.scanStub = Sinon.stub(this.server, "scan");
+
+                this.server.mount("endpoint", "path/to/*.js");
+            });
+
+            after(() => {
+                this.scanStub.restore();
+            });
+
+            it("should have been called the scan method", () => {
+                this.scanStub.should.be.calledOnce.and.calledWithExactly("path/to/*.js", "endpoint");
+            });
+
+        });
+        describe("when we give an array of path", () => {
+            before(() => {
+                this.scanStub = Sinon.stub(this.server, "scan");
+
+                this.server.mount("endpoint", ["path/to/*.js", "path2/to/*.js"]);
+            });
+
+            after(() => {
+                this.scanStub.restore();
+            });
+
+            it("should have been called the scan method", () => {
+                this.scanStub.should.be
+                    .calledTwice
+                    .and
+                    .calledWithExactly("path/to/*.js", "endpoint")
+                    .and
+                    .calledWithExactly("path2/to/*.js", "endpoint");
+            });
+        });
+    });
+
     describe("start()", () => {
 
         describe("when success", () => {


### PR DESCRIPTION


<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Status | Migration
---|---|---
Feature | In development | No

****

## Description

Closes: #84 

Actually, ServerSettings accept one Glob for one global endpoint.

As a developer, I want to be able to configure a set of files for the same global endpoint.

## Usage Example

```typescript
@ServerSettings({
   mount: {
       '/rest': [
            'controllers/accounts/*.js',
            'controllers/documents/*.js'
       ]
   }
})
class Server extends ServerLoader {

}
```

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation