### PR TITLE
Add Store to Index

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,6 +8,7 @@ export * from "./utils";
 export * from "./class/Metadata";
 export * from "./class/Registry";
 export * from "./class/ProxyRegistry";
+export * from "./class/Store";
 
 // Services
 export * from "./services/ExpressApplication";


### PR DESCRIPTION
In the documentation the import is described as:
import {Store, UseBefore} from "ts-express-decorators";
Hence the Store should be in the Index?

