### PR TITLE
importHelpers true but no lib dependency?

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "source-map-support": "^0.4.15",
     "ts-httpexceptions": "^2.2.1",
     "ts-log-debug": "^3.0.0",
+    "tslib": "^1.7.1",
     "swagger-schema-official": "^2.0.0-bab6bed"
   },
   "devDependencies": {


### PR DESCRIPTION
It seems importHelpers was added to tsconfig.json but no dependency on tslib was added to package.json?
This seems like a natural dependency else the build will fail.