### PR TITLE
FIX IControllerMiddlewares needs to be exported

### DIFF
--- a/src/mvc/class/ControllerProvider.ts
+++ b/src/mvc/class/ControllerProvider.ts
@@ -8,10 +8,11 @@ import {Type} from "../../core/interfaces";
 import {getClass} from "../../core/utils";
 import {Provider} from "../../di/class/Provider";
 
-import {IControllerOptions, IRouterOptions} from "../interfaces";
+import {IControllerOptions, IRouterOptions, IControllerMiddlewares} from "../interfaces";
 import {IChildrenController} from "../interfaces/IChildrenController";
 import {EndpointRegistry} from "../registries/EndpointRegistry";
 import {EndpointMetadata} from "./EndpointMetadata";
+
 
 
 /**

--- a/src/mvc/interfaces/IControllerMiddlewares.ts
+++ b/src/mvc/interfaces/IControllerMiddlewares.ts
@@ -1,5 +1,5 @@
 
-interface IControllerMiddlewares {
+export interface IControllerMiddlewares {
     useBefore?: any[];
     use?: any[];
     useAfter?: any[];

--- a/src/mvc/interfaces/IControllerOptions.ts
+++ b/src/mvc/interfaces/IControllerOptions.ts
@@ -5,6 +5,7 @@
 import {Type} from "../../core/interfaces";
 import {IRouterOptions} from "./IRouterOptions";
 import {PathParamsType} from "./PathParamsType";
+import { IControllerMiddlewares } from './IControllerMiddlewares';
 
 /**
  *

--- a/src/mvc/interfaces/index.ts
+++ b/src/mvc/interfaces/index.ts
@@ -8,6 +8,7 @@ export * from "./IMiddleware";
 export * from "./IMiddlewareError";
 export * from "./IMiddlewareOptions";
 export * from "./IMiddlewareProvider";
+export * from "./IControllerMiddlewares";
 export * from "./IRouterOptions";
 export * from "./MiddlewareType";
 export * from "./IInjectableParamSettings";


### PR DESCRIPTION
Currently 2.3.0+ of ts-express-decorators is failing when used.

Fixed by pull request.

Errors in my build:
node_modules/ts-express-decorators/lib/mvc/class/ControllerProvider.d.ts(95,18): error TS2304: Cannot find name 'IControllerMiddlewares'.
node_modules/ts-express-decorators/lib/mvc/interfaces/IControllerOptions.d.ts(16,19): error TS2304: Cannot find name 'IControllerMiddlewares'.

