### PR TITLE
Fix link to github repo on Ts.ED homepage

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -9,6 +9,6 @@
 * Dependency Injection,
 * Rest route and controller, param data injection support.
 
-[GitHub](https://github.com/Romakita/ts-log-debug/)
+[GitHub](https://github.com/Romakita/ts-express-decorators/)
 [Get Started](#tsed)
 


### PR DESCRIPTION
Found on https://romakita.github.io/ts-express-decorators/#/
