### PR TITLE
feat(converter): Add global option validationModelStrict.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,7 @@ new Server.start();
 * `swagger` &lt;Object&gt;: Object configure swagger. See more on [Swagger](tutorials/swagger.md).
 * `debug` &lt;boolean&gt;: Enable debug mode. By default debug is false.
 * `routers` &lt;object&gt;: Global configuration for the Express.Router. See express [documentation](http://expressjs.com/en/api.html#express.router).
+* `validationModelStrict` &lt;boolean&gt;: Use a strict validation when a model is used by the converter. When a property is unknow, it throw a BadRequest. By default true.
 
 ### Logger
 #### Default logger
@@ -160,6 +161,23 @@ export class CustomLogIncomingRequestMiddleware extends LogIncomingRequestMiddle
            params: request.params
         }
     }
+}
+```
+
+### Disable strict model validation
+
+Since v1.6, [ConverterService](docs/converters.md) check the consistency between the model and the Json object given to the endpoint.
+
+!> When a property is unknown on the model, Ts.Ed throw a BadRequest.
+
+You disable this behavior like here:
+
+```typescript
+@ServerSettings({
+   validationModelStrict: false
+})
+export class Server extends ServerLoader {
+
 }
 ```
 

--- a/src/converters/services/ConverterService.ts
+++ b/src/converters/services/ConverterService.ts
@@ -2,11 +2,8 @@ import {BadRequest} from "ts-httpexceptions";
 import {Metadata} from "../../core/class/Metadata";
 import {getClass, isArrayOrArrayClass, isEmpty, isPrimitiveOrPrimitiveClass} from "../../core/utils";
 import {InjectorService} from "../../di";
-/**
- * @module common/converters
- */
-/** */
 import {Service} from "../../di/decorators/service";
+import {ServerSettingsService} from "../../server/services/ServerSettingsService";
 import {PropertyMetadata} from "../class/PropertyMetadata";
 import {CONVERTER} from "../constants/index";
 import {ConverterDeserializationError} from "../errors/ConverterDeserializationError";
@@ -18,9 +15,10 @@ import {PropertyRegistry} from "../registries/PropertyRegistry";
 
 @Service()
 export class ConverterService {
+    private validationModelStrict = true;
 
-    constructor(private injectorService: InjectorService) {
-
+    constructor(private injectorService: InjectorService, serverSettings: ServerSettingsService) {
+        this.validationModelStrict = serverSettings.get<boolean>("validationModelStrict");
     }
 
     /**
@@ -84,7 +82,7 @@ export class ConverterService {
                     if (typeof obj[propertyKey] !== "function") {
                         let propertyMetadata = ConverterService.getPropertyMetadata(properties, propertyKey);
 
-                        if (getClass(obj) !== Object && propertyMetadata === undefined) {
+                        if (this.validationModelStrict && getClass(obj) !== Object && propertyMetadata === undefined) {
                             throw new UnknowPropertyError(getClass(obj), propertyKey);
                         }
 
@@ -194,7 +192,7 @@ export class ConverterService {
     private convertProperty = (obj: any, instance: any, propertyName: string, propertyMetadata?: PropertyMetadata) => {
 
 
-        if (getClass(instance) !== Object && propertyMetadata === undefined) {
+        if (this.validationModelStrict && getClass(instance) !== Object && propertyMetadata === undefined) {
             throw new UnknowPropertyError(getClass(instance), propertyName);
         }
 

--- a/src/server/class/ServerSettingsProvider.ts
+++ b/src/server/class/ServerSettingsProvider.ts
@@ -204,6 +204,15 @@ export class ServerSettingsProvider implements IServerSettings {
         this.map.set("routers", options);
     }
 
+    get validationModelStrict(): boolean {
+        const value = this.map.get("validationModelStrict");
+        return value === undefined ? true : value;
+    }
+
+    set validationModelStrict(value: boolean) {
+        this.map.set("validationModelStrict", value);
+    }
+
     /**
      *
      * @param propertyKey

--- a/src/server/decorators/serverSettings.ts
+++ b/src/server/decorators/serverSettings.ts
@@ -68,6 +68,7 @@ import {IServerSettings} from "../interfaces/IServerSettings";
  * * `componentsScan` &lt;string[]&gt;: List of directories to scan [Services](docs/services/ovierview.md), [Middlewares](docs/middlewares/ovierview.md) or [Converters](docs/converters.md).
  * * `serveStatic` &lt;[IServerMountDirectories](api/common/server/iservermountdirectories.md)&gt;: Objet to mount all directories under to his endpoints. See more on [Serve Static](tutorials/serve-static-files.md).
  * * `routers` &lt;object&gt;: Global configuration for the Express.Router. See express [documentation](http://expressjs.com/en/api.html#express.router).
+ * * `validationModelStrict` &lt;boolean&gt;: Use a strict validation when a model is used by the converter. When a property is unknow, it throw a BadRequest. By default true.
  *
  * @param settings
  * @returns {(target:any)=>any}

--- a/src/server/interfaces/IServerSettings.ts
+++ b/src/server/interfaces/IServerSettings.ts
@@ -28,6 +28,7 @@ export interface IServerSettings {
     serveStatic?: IServerMountDirectories;
     acceptMimes?: string[];
     debug?: boolean;
+    validationModelStrict?: boolean;
 
     [key: string]: any;
 }

--- a/src/server/services/ServerSettingsService.ts
+++ b/src/server/services/ServerSettingsService.ts
@@ -181,6 +181,11 @@ export class ServerSettingsService implements IServerSettings {
         return this.map.get("routers") || {};
     }
 
+    get validationModelStrict(): boolean {
+        const value = this.map.get("validationModelStrict");
+        return value === undefined ? true : value;
+    }
+
     /**
      *
      * @param callbackfn

--- a/test/units/converters/services/ConverterService.spec.ts
+++ b/test/units/converters/services/ConverterService.spec.ts
@@ -83,6 +83,13 @@ class Foo4 {
 }
 
 
+class Foo5 {
+    @JsonProperty()
+    test: any;
+    foo: any;
+}
+
+
 describe("ConverterService", () => {
 
     before(inject([ConverterService], (converterService: ConverterService) => {
@@ -271,7 +278,12 @@ describe("ConverterService", () => {
             it("should emit a BadRequest when the number parsing failed", () =>
                 assert.throws(() => this.converterService.deserialize("NK1", Number), "Cast error. Expression value is not a number.")
             );
+        });
 
+        describe("when validationModelStrict is enabled", () => {
+            before(() => {
+                this.converterService.validationModelStrict = true;
+            });
             it("should emit a BadRequest when a property is not in the Model", () => {
                 assert.throws(() =>
                         this.converterService.deserialize({
@@ -281,6 +293,30 @@ describe("ConverterService", () => {
                         }, <any>Foo4),
                     "Property notPropertyAllowed on class Foo4 is not allowed."
                 );
+            });
+        });
+
+        describe("when validationModelStrict is disabled", () => {
+            before(() => {
+                this.converterService.validationModelStrict = false;
+            });
+            after(() => {
+                this.converterService.validationModelStrict = true;
+            });
+
+            it("should not emit a BadRequest", () => {
+                const foo = new Foo5();
+                Object.assign(foo, {
+                    "foo": "test",
+                    "notPropertyAllowed": "tst",
+                    "test": 1
+                });
+
+                expect(this.converterService.deserialize({
+                    test: 1,
+                    foo: "test",
+                    notPropertyAllowed: "tst"
+                }, <any>Foo5)).to.deep.eq(foo);
             });
         });
 

--- a/test/units/server/services/ServerSettings.spec.ts
+++ b/test/units/server/services/ServerSettings.spec.ts
@@ -110,6 +110,14 @@ describe("ServerSettingsProvider", () => {
         expect(this.serverSettingsService.routers).to.deep.equal({mergeParams: true});
     });
 
+    it("should return validationModelStrict", () => {
+        expect(this.serverSettingsService.validationModelStrict).to.equal(true);
+        expect(this.serverSettingsProvider.validationModelStrict).to.equal(true);
+
+        this.serverSettingsProvider.validationModelStrict = false;
+        expect(this.serverSettingsProvider.validationModelStrict).to.equal(false);
+    });
+
     describe("forEach()", () => {
         before(() => {
             this.result = [];


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Status | Migration
---|---|---
Featuren | Ready | No

****

## Description
Since v1.6, [ConverterService](http://romakita.github.io/ts-express-decorators/docs/converters.md)
check the consistency between the model and the Json object given to the endpoint.
When a property is unknown on the model, Ts.Ed throw a BadRequest.
You can revert it with validationModelStrict options (ServerSettings).

Closes: #146