### PR TITLE
Fixed missing security definitions

### DIFF
--- a/src/swagger/class/OpenApiEndpointBuilder.ts
+++ b/src/swagger/class/OpenApiEndpointBuilder.ts
@@ -33,6 +33,7 @@ export class OpenApiEndpointBuilder extends OpenApiPropertiesBuilder {
         const produces = this.endpoint.get("produces") || [];
         const consumes = this.endpoint.get("consumes") || [];
         const responses = this.endpoint.get("responses") || {};
+        const security = this.endpoint.get("security") || {};
         const operationId = getOperationId(`${this.endpoint.targetName}.${this.endpoint.methodClassName}`);
         const openApiParamsBuilder = new OpenApiParamsBuilder(this.endpoint.target, this.endpoint.methodClassName);
 
@@ -51,6 +52,7 @@ export class OpenApiEndpointBuilder extends OpenApiPropertiesBuilder {
             parameters: openApiParamsBuilder.parameters,
             consumes,
             responses,
+            security,
             produces
         };
 


### PR DESCRIPTION
fix(swagger): the latest release were not backwards compatible.

It should probably be decided whether all operation specific information should be moved to the dedicated _operation_ namespace, meaning removing all the following (Not backwards compatible):
```typescript
    const produces = this.endpoint.get("produces") || [];
    const consumes = this.endpoint.get("consumes") || [];
    const responses = this.endpoint.get("responses") || {};
    const security = this.endpoint.get("security") || {};
```
then one could NOT write:

```typescript
.merge("responses", {"401": {description: "No authorization token was found"}})
.merge("security", [{"Token": [scope]}]);
```

but would have to put everything in the _operation_ namespace:

```typescript
  .merge("operation", {
              security: [{"Token": [scope]}],
              responses: {"401": {description: "No authorization token was found"}}
   });
```

For now I vote for keeping both - hence this PR

