### PR TITLE
feat(di): Add OverrideService decorator

### DIFF
--- a/docs/docs/middlewares/override-middleware.md
+++ b/docs/docs/middlewares/override-middleware.md
@@ -1,8 +1,7 @@
 # Override a Middleware
-> Beta feature. Need improvement. You can contribute !
 
-The decorator [@OverrideMiddleware](api/common/mvc/overridemiddleware.md) give you a solution to 
-override some embed Ts.ED middleware like the [SendResponseMiddleware](api/common/mvc/sendresponsemiddleware.md).
+The decorator [@OverrideMiddleware](api/common/mvc/overridemiddleware.md) gives you the ability to 
+override some internal Ts.ED middleware like the [SendResponseMiddleware](api/common/mvc/sendresponsemiddleware.md).
 
 For example, this is the current implementation of the [SendResponseMiddleware](api/common/mvc/sendresponsemiddleware.md).
 ```typescript
@@ -37,7 +36,7 @@ export class SendResponseMiddleware implements IMiddleware {
 
 ```
 
-But for a certain reason, this implementation isn't enough to meet your needs.
+But for some reason, this implementation isn't enough to meet your needs.
 
 With [@OverrideMiddleware](api/common/mvc/overridemiddleware.md) it's now possible to change the default implementation like
 this:
@@ -60,7 +59,7 @@ export class MySendResponseMiddleware extends SendResponseMiddleware {
 ```
 > Extends SendResponseMiddleware is optional. 
 
-And that all !
+And that is all!
 
 
 > All Ts.ED middlewares can be overrided. You can find the complete list [here](api/index.md?query=keywords_Middleware|type_class).

--- a/docs/docs/services/overview.md
+++ b/docs/docs/services/overview.md
@@ -71,3 +71,18 @@ class MyController {
     }
 }  
 ```
+
+### Override a Service
+
+The decorator [@OverrideService](api/common/di/overrideservice.md) gives you the ability to 
+override some internal Ts.ED service like the [ParseService](api/common/filters/parseservice.md).
+
+Example usage:
+```typescript
+import {OverrideService, ParseService} from "ts-express-decorators"
+
+@OverrideService(ParseService)
+class CustomParseService extends ParseService {
+    
+}
+```

--- a/src/core/class/Registry.ts
+++ b/src/core/class/Registry.ts
@@ -90,7 +90,7 @@ export class Registry<T, O> {
      * @param target
      * @param options
      */
-    merge(target: Type<any> | symbol, options: O): void {
+    merge(target: Type<any> | symbol, options: Partial<O>): void {
 
         const meta: T & { [key: string]: any } = this.createIfNotExists(target);
 

--- a/src/di/decorators/overrideService.ts
+++ b/src/di/decorators/overrideService.ts
@@ -1,0 +1,14 @@
+import {Type} from "../../core/interfaces";
+import {ProviderRegistry} from "../registries/ProviderRegistry";
+
+/**
+ * Override a service which is already registered in ProviderRegistry.
+ * @returns {Function}
+ * @decorators
+ * @param targetService
+ */
+export function OverrideService(targetService: Type<any>): Function {
+    return (target: Type<any>): void => {
+        ProviderRegistry.merge(targetService, {useClass: target});
+    };
+}

--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -4,5 +4,6 @@
  */ /** */
 export * from "./interfaces";
 export * from "./decorators/service";
+export * from "./decorators/overrideService";
 export * from "./decorators/inject";
 export * from "./services/InjectorService";

--- a/src/di/services/InjectorService.ts
+++ b/src/di/services/InjectorService.ts
@@ -271,8 +271,6 @@ export class InjectorService extends ProxyRegistry<Provider<any>, IProviderOptio
     static construct<T>(target: Type<any> | symbol): T {
 
         const provider: Provider<any> = ProviderRegistry.get(target)!;
-
-        /* istanbul ignore else */
         return this.invoke<any>(provider.useClass);
     }
 

--- a/src/mvc/decorators/class/overrideMiddleware.ts
+++ b/src/mvc/decorators/class/overrideMiddleware.ts
@@ -1,11 +1,12 @@
 import {Type} from "../../../core/interfaces";
-/**
- * @module common/mvc
- */
-/** */
 import {IMiddleware} from "../../interfaces";
 import {MiddlewareRegistry} from "../../registries/MiddlewareRegistry";
-
+/**
+ * Override a middleware which is already registered in MiddlewareRegistry.
+ * @param {Type<any> & IMiddleware} targetMiddleware
+ * @returns {Function}
+ * @decorators
+ */
 export function OverrideMiddleware(targetMiddleware: Type<any> & IMiddleware): Function {
     return (target: any): void => {
         MiddlewareRegistry.merge(targetMiddleware, {useClass: target});

--- a/test/units/di/decorators/overrideService.spec.ts
+++ b/test/units/di/decorators/overrideService.spec.ts
@@ -1,0 +1,25 @@
+import {OverrideService} from "../../../../src/di/decorators/overrideService";
+import {ProviderRegistry} from "../../../../src/di/registries/ProviderRegistry";
+import {Sinon} from "../../../tools";
+
+class Test {
+}
+
+class Test2 {
+}
+
+describe("OverrideService", () => {
+    before(() => {
+        this.mergeStub = Sinon.stub(ProviderRegistry, "merge");
+
+        OverrideService(Test)(Test2);
+    });
+
+    after(() => {
+        this.mergeStub.restore();
+    });
+
+    it("should set metadata", () => {
+        this.mergeStub.should.be.calledWithExactly(Test, {useClass: Test2});
+    });
+});

--- a/test/units/di/decorators/service.spec.ts
+++ b/test/units/di/decorators/service.spec.ts
@@ -1,0 +1,22 @@
+import {Service} from "../../../../src/di/decorators/service";
+import {InjectorService} from "../../../../src/di/services/InjectorService";
+import {Sinon} from "../../../tools";
+
+class Test {
+}
+
+describe("Service", () => {
+    before(() => {
+        this.serviceStub = Sinon.stub(InjectorService, "service");
+
+        Service()(Test);
+    });
+
+    after(() => {
+        this.serviceStub.restore();
+    });
+
+    it("should set metadata", () => {
+        this.serviceStub.should.be.calledWithExactly(Test);
+    });
+});


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Status | Migration
---|---|---
Feature | Ready | No

****

## Description
Add a decorators to override a Service.

## Usage example

The decorator [@OverrideService](api/common/di/overrideservice.md) give you a solution to 
override some embed Ts.ED service like the [ParseService](api/common/filters/parseservice.md).

Example usage:
```typescript
import {OverrideService, ParseService} from "ts-express-decorators"

@OverrideService(ParseService)
class CustomParseService extends ParseService {
    
}
```
## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation