### PR TITLE
chore(logging): moved to request logging to debug instead of info

### DIFF
--- a/src/mvc/components/GlobalErrorHandlerMiddleware.ts
+++ b/src/mvc/components/GlobalErrorHandlerMiddleware.ts
@@ -26,7 +26,7 @@ export class GlobalErrorHandlerMiddleware implements IMiddlewareError {
         const toHTML = (message = "") => message.replace(/\n/gi, "<br />");
 
         if (error instanceof Exception || error.status) {
-            $log.error("" + error);
+            request.log.error({ERROR: error});
             response.status(error.status).send(toHTML(error.message));
             return;
         }
@@ -36,7 +36,7 @@ export class GlobalErrorHandlerMiddleware implements IMiddlewareError {
             return;
         }
 
-        $log.error(error);
+        request.log.error({ERROR: error});
         response.status(error.status || 500).send("Internal Error");
 
         return;

--- a/src/mvc/components/LogIncomingRequestMiddleware.ts
+++ b/src/mvc/components/LogIncomingRequestMiddleware.ts
@@ -45,7 +45,7 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
      * @param {e.Request} request
      */
     protected onLogStart(request: Express.Request) {
-        request.log.info();
+        request.log.debug();
     }
 
     /**
@@ -120,7 +120,7 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
             const status = (response as any)._header
                 ? response.statusCode
                 : undefined;
-            request.log.info({status, data: request.getStoredData && request.getStoredData()});
+            request.log.debug({status, data: request.getStoredData && request.getStoredData()});
             this.cleanRequest(request);
         }
     }

--- a/src/swagger/class/OpenApiPropertiesBuilder.ts
+++ b/src/swagger/class/OpenApiPropertiesBuilder.ts
@@ -112,7 +112,7 @@ export class OpenApiPropertiesBuilder {
     }
 
     public getJsonSchema() {
-        const schema = Store.from(this.target).get<Schema>("schema");
+        const schema = Store.from(this.target).get<Schema>("schema") || {};
         return schema.toJSON ? schema.toJSON() : schema;
     }
 

--- a/test/helper/FakeRequest.ts
+++ b/test/helper/FakeRequest.ts
@@ -1,3 +1,4 @@
+
 export class FakeRequest {
     method: string;
     path: string;
@@ -6,6 +7,18 @@ export class FakeRequest {
     tagId: string;
     _responseData: any;
     public accepts = (mime: string) => this.mime === mime;
+
+    public log: Express.RequestLogger = {
+        debug: (scope?: any) => {},
+        
+        info: (scope?: any) => {},
+        
+        trace: (scope?: any) => {},
+        
+        warn: (scope?: any) => {},
+        
+        error: (scope?: any) => {}
+    };
 
     /**
      *

--- a/test/units/mvc/components/GlobalErrorHandlerMiddleware.spec.ts
+++ b/test/units/mvc/components/GlobalErrorHandlerMiddleware.spec.ts
@@ -33,7 +33,7 @@ describe("GlobalErrorHandlerMiddleware", () => {
 
                 this.middleware.use(
                     this.error,
-                    this.responseStub,
+                    this.request,
                     this.response
                 );
             });
@@ -54,7 +54,7 @@ describe("GlobalErrorHandlerMiddleware", () => {
 
                 this.middleware.use(
                     this.error,
-                    this.responseStub,
+                    this.request,
                     this.response
                 );
             });
@@ -78,7 +78,7 @@ describe("GlobalErrorHandlerMiddleware", () => {
 
                 this.middleware.use(
                     this.error,
-                    this.responseStub,
+                    this.request,
                     this.response
                 );
             });

--- a/test/units/mvc/components/LogIncomingRequestMiddleware.spec.ts
+++ b/test/units/mvc/components/LogIncomingRequestMiddleware.spec.ts
@@ -278,7 +278,7 @@ describe("LogIncomingRequestMiddleware", () => {
                 query: {query: "query"},
                 params: {params: "params"},
                 log: {
-                    info: Sinon.stub()
+                    debug: Sinon.stub()
                 },
                 getStoredData: () => "test"
             };
@@ -289,7 +289,7 @@ describe("LogIncomingRequestMiddleware", () => {
         }));
 
         it("should have been called the logger with the right parameters", () => {
-            this.request.log.info.should.be.calledWithExactly({status: undefined, data: "test"});
+            this.request.log.debug.should.be.calledWithExactly({status: undefined, data: "test"});
         });
 
         it("should clean the request object", () => {


### PR DESCRIPTION
chore(logging): moved the request logging to debug instead of info

In an attempt to reduce the ordinary logging the request logging was moved to debug level

@Romakita 
Maybe the real solution would be to split out the request logging in an info part and a debug part. However including the sometimes extreme amounts of data in the info part renders my info logging level worthless :-(