### PR TITLE
fix(swagger): the properties builder will not fail when no model deco…

### DIFF
--- a/src/swagger/class/OpenApiPropertiesBuilder.ts
+++ b/src/swagger/class/OpenApiPropertiesBuilder.ts
@@ -112,7 +112,7 @@ export class OpenApiPropertiesBuilder {
     }
 
     public getJsonSchema() {
-        const schema = Store.from(this.target).get<Schema>("schema");
+        const schema = Store.from(this.target).get<Schema>("schema") || {};
         return schema.toJSON ? schema.toJSON() : schema;
     }
 

--- a/test/units/swagger/class/OpenApiPropertiesBuilder.spec.ts
+++ b/test/units/swagger/class/OpenApiPropertiesBuilder.spec.ts
@@ -1,7 +1,7 @@
 import {OpenApiPropertiesBuilder} from "../../../../src/swagger/class/OpenApiPropertiesBuilder";
 import {Description} from "../../../../src/swagger/decorators/description";
 import {expect} from "../../../tools";
-import {SwaFoo2} from "./helpers/classes";
+import { SwaFoo2, SwaNoDecoModel } from './helpers/classes';
 
 describe("OpenApiPropertiesBuilder", () => {
 
@@ -9,6 +9,15 @@ describe("OpenApiPropertiesBuilder", () => {
         this.schemaBuilder = new OpenApiPropertiesBuilder(SwaFoo2);
         this.schemaBuilder.build();
     });
+
+    it("should not fail", ()=> {
+        let builder = new OpenApiPropertiesBuilder(SwaNoDecoModel);
+        
+        let build = () => {builder.build();}
+           
+        expect(build).to.not.throw();
+    })
+
 
     it("should create a schema", () => {
         expect(this.schemaBuilder.schema).to.deep.eq({

--- a/test/units/swagger/class/helpers/classes.ts
+++ b/test/units/swagger/class/helpers/classes.ts
@@ -3,6 +3,10 @@ import {Required} from "../../../../../src/mvc/decorators";
 import {Description} from "../../../../../src/swagger/decorators/description";
 import {Title} from "../../../../../src/swagger/decorators/title";
 
+export class SwaNoDecoModel {
+    public prop: string;
+}
+
 export class SwaBaseModel {
     @Title("id")
     @Description("Unique identifier.")


### PR DESCRIPTION
fix(swagger): the properties builder should not fail when no model decoration is present.

The current release fails (at runtime) when the model used in Controller carries no JsonProperty decorator. This fix lets the schema creation be less restrictive and adds a test for the building of non decorated models.
