### PR TITLE
Fix: Performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,9 @@
     "reflect-metadata": "^0.1.8",
     "source-map-support": "^0.5.0",
     "ts-httpexceptions": "^2.2.1",
-    "ts-log-debug": "^3.0.0",
-    "tslib": "^1.7.1"
+    "ts-log-debug": "^3.0.1",
+    "tslib": "^1.7.1",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/src/config/class/ServerSettingsProvider.ts
+++ b/src/config/class/ServerSettingsProvider.ts
@@ -3,9 +3,10 @@ import {Env, Metadata} from "../../core";
 import {getValue} from "../../core/utils";
 import {SERVER_SETTINGS} from "../constants";
 import {IRouterOptions} from "../interfaces/IRouterOptions";
-import {IServerMountDirectories, IServerSettings} from "../interfaces/IServerSettings";
+import {ILoggerSettings, IServerMountDirectories, IServerSettings} from "../interfaces/IServerSettings";
 
 const rootDir = process.cwd();
+let REQ_ID = 0;
 
 export class ServerSettingsProvider implements IServerSettings {
 
@@ -21,6 +22,9 @@ export class ServerSettingsProvider implements IServerSettings {
         this.version = "1.0.0";
         this.uploadDir = "${rootDir}/uploads";
         this.debug = false;
+        this.logger = {
+            logRequest: true
+        };
 
         /* istanbul ignore next */
         this.authentification = () => (true);
@@ -314,6 +318,19 @@ export class ServerSettingsProvider implements IServerSettings {
      */
     set validationModelStrict(value: boolean) {
         this.map.set("validationModelStrict", value);
+    }
+
+    get logger(): Partial<ILoggerSettings> {
+        const debug = this.debug;
+        const requestFields = this.get("logRequestFields");
+        return Object.assign({
+            requestFields,
+            debug
+        }, this.map.get("logger"));
+    }
+
+    set logger(value: Partial<ILoggerSettings>) {
+        this.map.set("logger", value);
     }
 
     /**

--- a/src/config/interfaces/IServerSettings.ts
+++ b/src/config/interfaces/IServerSettings.ts
@@ -10,6 +10,13 @@ export interface IServerMountDirectories {
     [endpoint: string]: string | string[];
 }
 
+export interface ILoggerSettings {
+    debug?: boolean;
+    requestFields?: ("reqId" | "method" | "url" | "headers" | "body" | "query" | "params" | "duration")[];
+    logRequest?: boolean;
+    reqIdBuilder: () => number;
+}
+
 export interface IServerSettings {
     rootDir?: string;
     /**
@@ -29,6 +36,7 @@ export interface IServerSettings {
     debug?: boolean;
     logRequestFields?: ("reqId" | "method" | "url" | "headers" | "body" | "query" | "params" | "duration")[];
     validationModelStrict?: boolean;
+    logger?: Partial<ILoggerSettings>;
 
     [key: string]: any;
 }

--- a/src/mvc/class/EndpointBuilder.ts
+++ b/src/mvc/class/EndpointBuilder.ts
@@ -1,14 +1,8 @@
-/**
- * @module common/mvc
- */
-/** */
-
-import {$log} from "ts-log-debug";
+import {globalServerSettings} from "../../config";
 import {nameOf} from "../../core/utils";
 import {SendResponseMiddleware} from "../components/SendResponseMiddleware";
 import {EndpointMetadata} from "./EndpointMetadata";
 import {HandlerBuilder} from "./HandlerBuilder";
-
 /**
  *
  */
@@ -24,25 +18,16 @@ export class EndpointBuilder {
         (request: any, response: any, next: any) => {
 
             /* istanbul ignore else */
-            if (request.id) {
-                $log.debug(request.tagId, "Endpoint =>", JSON.stringify({
+            if (request.id && globalServerSettings.debug) {
+                request.log.debug({
+                    event: "attach.endpoint",
                     target: nameOf(this.endpoint.target),
                     methodClass: this.endpoint.methodClassName,
                     httpMethod: this.endpoint.httpMethod
-                }));
+                });
             }
 
-            request.getEndpoint = () => this.endpoint;
-
-            request.storeData = function (data: any) {
-                this._responseData = data;
-                return this;
-            };
-
-            request.getStoredData = function () {
-                return this._responseData;
-            };
-
+            request.setEndpoint(this.endpoint);
             next();
         };
 

--- a/src/mvc/class/HandlerBuilder.ts
+++ b/src/mvc/class/HandlerBuilder.ts
@@ -1,3 +1,4 @@
+import {globalServerSettings} from "../../config";
 import {ConverterService} from "../../converters/services/ConverterService";
 import {CastError} from "../../core/errors/CastError";
 import {Type} from "../../core/interfaces";
@@ -43,7 +44,6 @@ export class HandlerBuilder {
      * @returns {any}
      */
     public build() {
-
         if (this.handlerMetadata.errorParam) {
             return (err: any, request: any, response: any, next: any) => {
                 return this.invoke({err, request, response, next});
@@ -157,7 +157,7 @@ export class HandlerBuilder {
      * @returns {string}
      */
     private log(request: Express.Request, o: any = {}) {
-        if (request.tagId) {
+        if (request.id && globalServerSettings.debug) {
             const target = this.handlerMetadata.target;
             const injectable = this.handlerMetadata.injectable;
             const methodName = this.handlerMetadata.methodClassName;
@@ -182,19 +182,14 @@ export class HandlerBuilder {
      */
     private buildNext(request: Express.Request, response: Express.Response, next: Express.NextFunction): any {
         return (error?: any) => {
-            try {
-                next.isCalled = true;
-                if (response.headersSent) {
-                    return;
-                }
-
-                /* istanbul ignore else */
-                this.log(request, {event: "invoke.end", error});
-                return next(error);
-            } catch (er) {
-                er.originalError = error;
-                return next(er);
+            next.isCalled = true;
+            if (response.headersSent) {
+                return;
             }
+
+            /* istanbul ignore else */
+            this.log(request, {event: "invoke.end", error});
+            return next(error);
         };
     }
 
@@ -227,17 +222,9 @@ export class HandlerBuilder {
      * @returns {[(any|EndpointMetadata|any|any),(any|EndpointMetadata|any|any),(any|EndpointMetadata|any|any),(any|EndpointMetadata|any|any),(any|EndpointMetadata|any|any)]}
      */
     private getInjectableParameters(localScope: IHandlerScope = {} as IHandlerScope): any[] {
-
-        const converterService = InjectorService.get<ConverterService>(ConverterService);
-        const filterService = InjectorService.get<FilterService>(FilterService);
-        const validationService = InjectorService.get<ValidationService>(ValidationService);
-
         return this.handlerMetadata
             .services
             .map((param: ParamMetadata) => {
-
-                let paramValue;
-
                 if (param.name in localScope) {
                     return localScope[param.name];
                 }
@@ -250,41 +237,55 @@ export class HandlerBuilder {
                     return localScope["request"].getStoredData();
                 }
 
-                if (filterService.has(param.service as Type<any>)) {
-                    paramValue = filterService.invokeMethod(
-                        param.service as Type<any>,
-                        param.expression,
-                        localScope.request,
-                        localScope.response
-                    );
-                }
-
-                if (!param.isValidRequiredValue(paramValue)) {
-                    throw new RequiredParamError(param.name, param.expression);
-                }
-
-                try {
-
-                    if (param.useConverter) {
-                        const type = param.type || param.collectionType;
-                        paramValue = converterService.deserialize(paramValue, type, param.collectionType);
-
-                        if (type) {
-                            validationService.validate(paramValue, type, param.collectionType);
-                        }
-                    }
-
-                } catch (err) {
-                    /* istanbul ignore next */
-                    if (err.name === "BAD_REQUEST") {
-                        throw new ParseExpressionError(param.name, param.expression, err.message);
-                    } else {
-                        /* istanbul ignore next */
-                        throw new CastError(err);
-                    }
-                }
-
-                return paramValue;
+                return this.getParamValue(param, localScope);
             });
+    }
+
+    /**
+     *
+     * @param {ParamMetadata} param
+     * @param {IHandlerScope} localScope
+     * @returns {any}
+     */
+    private getParamValue(param: ParamMetadata, localScope: IHandlerScope = {} as IHandlerScope) {
+        let paramValue;
+        const filterService = InjectorService.get<FilterService>(FilterService);
+
+        if (filterService.has(param.service as Type<any>)) {
+            paramValue = filterService.invokeMethod(
+                param.service as Type<any>,
+                param.expression,
+                localScope.request,
+                localScope.response
+            );
+        }
+
+        if (!param.isValidRequiredValue(paramValue)) {
+            throw new RequiredParamError(param.name, param.expression);
+        }
+
+        try {
+            if (param.useConverter) {
+                const converterService = InjectorService.get<ConverterService>(ConverterService);
+                const type = param.type || param.collectionType;
+                paramValue = converterService.deserialize(paramValue, type, param.collectionType);
+
+                if (type) {
+                    const validationService = InjectorService.get<ValidationService>(ValidationService);
+                    validationService.validate(paramValue, type, param.collectionType);
+                }
+            }
+
+        } catch (err) {
+            /* istanbul ignore next */
+            if (err.name === "BAD_REQUEST") {
+                throw new ParseExpressionError(param.name, param.expression, err.message);
+            } else {
+                /* istanbul ignore next */
+                throw new CastError(err);
+            }
+        }
+
+        return paramValue;
     }
 }

--- a/src/mvc/components/GlobalErrorHandlerMiddleware.ts
+++ b/src/mvc/components/GlobalErrorHandlerMiddleware.ts
@@ -24,7 +24,13 @@ export class GlobalErrorHandlerMiddleware implements IMiddlewareError {
         const toHTML = (message = "") => message.replace(/\n/gi, "<br />");
 
         if (error instanceof Exception || error.status) {
-            request.log.error({error});
+            request.log.error({
+                error: {
+                    message: error.message,
+                    stack: error.stack,
+                    status: error.status
+                }
+            });
             response.status(error.status).send(toHTML(error.message));
             return;
         }
@@ -34,7 +40,13 @@ export class GlobalErrorHandlerMiddleware implements IMiddlewareError {
             return;
         }
 
-        request.log.error({error});
+        request.log.error({
+            error: {
+                status: 500,
+                message: error.message,
+                stack: error.stack
+            }
+        });
         response.status(error.status || 500).send("Internal Error");
 
         return;

--- a/src/mvc/components/LogIncomingRequestMiddleware.ts
+++ b/src/mvc/components/LogIncomingRequestMiddleware.ts
@@ -67,10 +67,9 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
 
         const verbose = (req: Express.Request) => this.requestToObject(req);
         const info = (req: Express.Request) => this.minimalRequestPicker(req);
-
         request.log = {
-            info: (obj: any) => $log.info(this.stringify(request, info)(obj)),
-            debug: (obj: any) => $log.debug(this.stringify(request, verbose)(obj)),
+            info: (obj: any) => setImmediate(() => $log.info(this.stringify(request, info)(obj))),
+            debug: (obj: any) => setImmediate(() => $log.debug(this.stringify(request, verbose)(obj))),
             warn: (obj: any) => $log.warn(this.stringify(request, verbose)(obj)),
             error: (obj: any) => $log.error(this.stringify(request, verbose)(obj)),
             trace: (obj: any) => $log.trace(this.stringify(request, verbose)(obj))
@@ -101,7 +100,6 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
      * @returns {Object}
      */
     protected minimalRequestPicker(request: Express.Request): any {
-
         const info = this.requestToObject(request);
 
         return this.logRequestFields.reduce((acc: any, key: string) => {
@@ -162,20 +160,23 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
      * @param request
      */
     protected cleanRequest(request: Express.Request) {
-        delete request.id;
-        delete request.tagId;
-        delete request.tsedReqStart;
-        request.log = {
-            info: () => {
-            },
-            debug: () => {
-            },
-            warn: () => {
-            },
-            error: () => {
-            },
-            trace: () => {
-            }
-        };
+        setImmediate(() => {
+            delete request.id;
+            delete request.tagId;
+            delete request.tsedReqStart;
+            request.log = {
+                info: () => {
+                },
+                debug: () => {
+                },
+                warn: () => {
+                },
+                error: () => {
+                },
+                trace: () => {
+                }
+            };
+        });
+
     }
 }

--- a/src/mvc/components/LogIncomingRequestMiddleware.ts
+++ b/src/mvc/components/LogIncomingRequestMiddleware.ts
@@ -4,6 +4,8 @@
 /** */
 import * as Express from "express";
 import {$log} from "ts-log-debug";
+import {globalServerSettings} from "../../config";
+import {ILoggerSettings} from "../../config/interfaces/IServerSettings";
 import {ServerSettingsService} from "../../config/services/ServerSettingsService";
 import {Env} from "../../core/interfaces";
 import {applyBefore} from "../../core/utils";
@@ -27,11 +29,15 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
 
     private AUTO_INCREMENT_ID = 1;
     private env: Env;
-    private logRequestFields: string[];
+    private loggerSettings: ILoggerSettings;
+    private fields: string[];
+    private reqIdBuilder: () => number;
 
     constructor(private serverSettingsService: ServerSettingsService) {
         this.env = serverSettingsService.env;
-        this.logRequestFields = serverSettingsService.get("logRequestFields") || LogIncomingRequestMiddleware.DEFAULT_FIELDS;
+        this.loggerSettings = serverSettingsService.logger as ILoggerSettings;
+        this.reqIdBuilder = this.loggerSettings.reqIdBuilder || (() => this.AUTO_INCREMENT_ID++);
+        this.fields = this.loggerSettings.requestFields || LogIncomingRequestMiddleware.DEFAULT_FIELDS;
     }
 
     /**
@@ -53,7 +59,7 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
      * @param {e.Request} request
      */
     protected onLogStart(request: Express.Request) {
-        request.log.debug();
+        request.log.debug({event: "start"});
     }
 
     /**
@@ -61,15 +67,14 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
      * @param request
      */
     protected configureRequest(request: Express.Request) {
-        request.id = String(request.id ? request.id : this.AUTO_INCREMENT_ID++);
-        request.tagId = `[#${(request as any).id}]`;
+        request.id = String(request.id ? request.id : this.reqIdBuilder());
         request.tsedReqStart = new Date();
 
         const verbose = (req: Express.Request) => this.requestToObject(req);
         const info = (req: Express.Request) => this.minimalRequestPicker(req);
         request.log = {
-            info: (obj: any) => setImmediate(() => $log.info(this.stringify(request, info)(obj))),
-            debug: (obj: any) => setImmediate(() => $log.debug(this.stringify(request, verbose)(obj))),
+            info: (obj: any) => $log.info(this.stringify(request, info)(obj)),
+            debug: (obj: any) => $log.debug(this.stringify(request, verbose)(obj)),
             warn: (obj: any) => $log.warn(this.stringify(request, verbose)(obj)),
             error: (obj: any) => $log.error(this.stringify(request, verbose)(obj)),
             trace: (obj: any) => $log.trace(this.stringify(request, verbose)(obj))
@@ -102,10 +107,11 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
     protected minimalRequestPicker(request: Express.Request): any {
         const info = this.requestToObject(request);
 
-        return this.logRequestFields.reduce((acc: any, key: string) => {
-            acc[key] = info[key];
-            return acc;
-        }, {});
+        return this.fields
+            .reduce((acc: any, key: string) => {
+                acc[key] = info[key];
+                return acc;
+            }, {});
     }
 
     /**
@@ -131,10 +137,15 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
 
             scope = Object.assign(scope, propertySelector(request));
 
-            if (this.env !== Env.PROD) {
-                return JSON.stringify(scope, null, 2);
+            try {
+                if (this.env !== Env.PROD) {
+                    return JSON.stringify(scope, null, 2);
+                }
+                return JSON.stringify(scope);
+            } catch (er) {
+                $log.error({error: er});
             }
-            return JSON.stringify(scope);
+            return "";
         };
     }
 
@@ -144,15 +155,22 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
      * @param response
      */
     protected onLogEnd(request: Express.Request, response: Express.Response) {
-        /* istanbul ignore else */
-        if (request.id) {
-            const status = (response as any)._header
-                ? response.statusCode
-                : undefined;
-            request.log.info({status});
-            request.log.debug({status, data: request.getStoredData && request.getStoredData()});
-            this.cleanRequest(request);
-        }
+        setImmediate(() => {
+            /* istanbul ignore else */
+            if (request.id) {
+                if (this.loggerSettings.logRequest) {
+                    request.log.info({status: response.statusCode});
+                }
+
+                if (globalServerSettings.debug) {
+                    request.log.debug({
+                        status: response.statusCode,
+                        data: request.getStoredData && request.getStoredData()
+                    });
+                }
+                this.cleanRequest(request);
+            }
+        });
     }
 
     /**
@@ -160,23 +178,20 @@ export class LogIncomingRequestMiddleware implements IMiddleware {
      * @param request
      */
     protected cleanRequest(request: Express.Request) {
-        setImmediate(() => {
-            delete request.id;
-            delete request.tagId;
-            delete request.tsedReqStart;
-            request.log = {
-                info: () => {
-                },
-                debug: () => {
-                },
-                warn: () => {
-                },
-                error: () => {
-                },
-                trace: () => {
-                }
-            };
-        });
-
+        delete request.id;
+        delete request.tagId;
+        delete request.tsedReqStart;
+        request.log = {
+            info: () => {
+            },
+            debug: () => {
+            },
+            warn: () => {
+            },
+            error: () => {
+            },
+            trace: () => {
+            }
+        };
     }
 }

--- a/src/mvc/index.ts
+++ b/src/mvc/index.ts
@@ -1,7 +1,10 @@
 /**
  * @module common/mvc
  * @preferred
- */ /** */
+ */
+/** */
+import "./utils/extendsRequest";
+
 export * from "./interfaces";
 
 // provide

--- a/src/mvc/utils/extendsRequest.ts
+++ b/src/mvc/utils/extendsRequest.ts
@@ -1,0 +1,49 @@
+const express = require("express");
+
+/**
+ *
+ * @param {string | any} obj
+ * @param {Function} value
+ */
+export function extendsRequest(obj: string | any, value?: Function | any) {
+    if (typeof obj === "object") {
+        Object.keys(obj).forEach((key) => {
+            extendsRequest(key, obj[key]);
+        });
+    } else {
+        Object.defineProperty(express.request, obj, typeof value === "function" ? {value} : value);
+    }
+}
+
+extendsRequest({
+    /**
+     *
+     * @param endpoint
+     */
+    setEndpoint(endpoint: any) {
+        this._endpoint = endpoint;
+    },
+    /**
+     *
+     * @returns {any}
+     */
+    getEndpoint() {
+        return this._endpoint;
+    },
+    /**
+     *
+     * @param data
+     * @returns {storeData}
+     */
+    storeData(data: any) {
+        this._responseData = data;
+        return this;
+    },
+    /**
+     *
+     * @returns {any}
+     */
+    getStoredData() {
+        return this._responseData;
+    }
+});

--- a/src/server/components/ServerLoader.ts
+++ b/src/server/components/ServerLoader.ts
@@ -17,8 +17,9 @@ import {InjectorService} from "../../di";
 
 import {GlobalErrorHandlerMiddleware} from "../../mvc";
 import {HandlerBuilder} from "../../mvc/class/HandlerBuilder";
-import {LogIncomingRequestMiddleware} from "../../mvc/components/LogIncomingRequestMiddleware";
+import {MiddlewareRegistry} from "../../mvc/registries/MiddlewareRegistry";
 import {IComponentScanned, IHTTPSServerOptions, IServerLifecycle} from "../interfaces";
+import {LogIncomingRequestMiddleware} from "../../mvc/components/LogIncomingRequestMiddleware";
 
 /**
  * ServerLoader provider all method to instantiate an ExpressServer.
@@ -161,11 +162,9 @@ export abstract class ServerLoader implements IServerLifecycle {
     public use(...args: any[]): ServerLoader {
 
         args = args.map((arg) => {
-
-            if (typeof arg === "function") {
+            if (MiddlewareRegistry.has(arg)) {
                 arg = HandlerBuilder.from(arg).build();
             }
-
             return arg;
         });
 

--- a/test/helper/FakeRequest.ts
+++ b/test/helper/FakeRequest.ts
@@ -5,6 +5,7 @@ export class FakeRequest {
     id: number;
     tagId: string;
     _responseData: any;
+    _endpoint: any;
     public accepts = (mime: string) => this.mime === mime;
 
     public log: Express.RequestLogger = {
@@ -86,12 +87,16 @@ export class FakeRequest {
     }
 
     public getEndpoint() {
-        return {
+        return this._endpoint || {
             store: {
                 get: () => {
                 }
             }
         };
+    }
+
+    public setEndpoint(endpoint: any) {
+        this._endpoint = endpoint;
     }
 
     public end() {

--- a/test/units/mvc/class/EndpointBuilder.spec.ts
+++ b/test/units/mvc/class/EndpointBuilder.spec.ts
@@ -1,5 +1,6 @@
 import * as Express from "express";
 import * as Proxyquire from "proxyquire";
+import {globalServerSettings} from "../../../../src/config";
 
 import {EndpointMetadata} from "../../../../src/mvc/class/EndpointMetadata";
 import {inject} from "../../../../src/testing/inject";
@@ -99,6 +100,7 @@ describe("EndpointBuilder", () => {
 
     describe("onRequest()", () => {
         before(() => {
+            globalServerSettings.debug = true;
             this.request = new FakeRequest();
             this.request.id = 1;
             this.response = new FakeResponse();
@@ -109,6 +111,7 @@ describe("EndpointBuilder", () => {
         });
 
         after(() => {
+            globalServerSettings.debug = false;
             this.response.setHeader.restore();
         });
 

--- a/test/units/mvc/class/HandlerBuilder.spec.ts
+++ b/test/units/mvc/class/HandlerBuilder.spec.ts
@@ -1,4 +1,5 @@
 import "../../../../src/ajv";
+import {globalServerSettings} from "../../../../src/config";
 import {ConverterService} from "../../../../src/converters/services/ConverterService";
 import {InjectorService} from "../../../../src/di/services/InjectorService";
 import {ENDPOINT_INFO, EXPRESS_ERR, RESPONSE_DATA} from "../../../../src/filters/constants";
@@ -125,383 +126,6 @@ describe("HandlerBuilder", () => {
                     });
                 });
             });
-
-            /*describe("from function with next func", () => {
-
-                before(inject([], () => {
-                    this.response = new FakeResponse();
-                    this.request = new FakeRequest();
-                    this.nextSpy = Sinon.spy();
-
-                    this.stub = Sinon.stub();
-
-                    this.metadata = {
-                        type: "function",
-                        nextFunction: true,
-                        errorParam: false,
-                        target: (req: any, res: any, next: any) => {
-                            this.stub(req, res, next);
-                            next();
-                        },
-                        isValidRequiredValue: () => true
-                    };
-
-                    this.middleware = new HandlerBuilder(this.metadata).build();
-                    this.middleware(this.request, this.response, this.nextSpy);
-                }));
-
-                it("should create middleware", () => {
-                    expect(this.middleware).to.be.a("function").and.length(3);
-                });
-
-                it("should call middleware with some parameters", () => {
-                    this.stub.should.calledWithExactly(this.request, this.response, Sinon.match.func);
-                });
-
-                it("should call next spy", () =>
-                    this.nextSpy.should.have.been.calledOnce
-                );
-            });
-
-            describe("from function without next func", () => {
-
-                before(() => {
-                    this.response = new FakeResponse();
-                    this.request = new FakeRequest();
-                    this.nextSpy = Sinon.spy();
-                    this.stub = Sinon.stub();
-
-                    this.metadata = {
-                        nextFunction: false,
-                        errorParam: false,
-                        target: (req: any, res: any) => {
-                            this.stub(req, res);
-                        }
-                    };
-
-                    this.middleware = new HandlerBuilder(this.metadata).build();
-                    this.middleware(this.request, this.response, this.nextSpy);
-                });
-
-                it("should create middleware", () => {
-                    expect(this.middleware).to.be.a("function").and.length(3);
-                });
-
-                it("should call middleware with some parameters", () => {
-                    this.stub.should.have.been.calledWithExactly(this.request, this.response);
-                });
-
-                it("should call next spy", () =>
-                    this.nextSpy.should.have.been.calledOnce
-                );
-            });
-
-            describe("from function with err", () => {
-
-                before(() => {
-                    this.response = new FakeResponse();
-                    this.request = new FakeRequest();
-                    this.nextSpy = Sinon.spy();
-                    this.stub = Sinon.stub();
-
-                    this.metadata = {
-                        nextFunction: true,
-                        errorParam: true,
-                        target: (err: any, req: any, res: any, next: any) => {
-                            this.stub(err, req, res, next);
-                            next(err);
-                        }
-                    };
-
-                    this.middleware = new HandlerBuilder(this.metadata).build();
-                    this.middleware(new Error, this.request, this.response, this.nextSpy);
-                });
-
-                it("should create middleware", () => {
-                    expect(this.middleware).to.be.a("function").and.length(4);
-                });
-
-                it("should call middleware with some parameters", () => {
-                    this.stub.should.have.been.calledWithExactly(
-                        Sinon.match.instanceOf(Error),
-                        this.request,
-                        this.response,
-                        Sinon.match.func
-                    );
-                });
-
-                it("should call next spy", () =>
-                    this.nextSpy.should.have.been.calledOnce
-                );
-            });
-
-            describe("from Endpoint", () => {
-
-                before(() => {
-                    this.response = new FakeResponse();
-                    this.request = new FakeRequest();
-                    this.nextSpy = Sinon.spy();
-                    this.getStub = Sinon.stub(Test.prototype, "get").returns({response: "body"});
-                    this.deserializeStub.returns({request: "body"});
-                    this.metadata = {
-                        type: "controller",
-                        injectable: true,
-                        nextFunction: false,
-                        errorParam: false,
-                        target: Test,
-                        methodClassName: "get",
-                        services: [{service: PathParamsFilter, useConverter: true, isValidRequiredValue: () => true}],
-                        instance: new Test
-                    };
-
-                    this.invokeMethodStub = Sinon.stub(FilterService.prototype, "invokeMethod").returns({request: "body"});
-
-                    this.middleware = new HandlerBuilder(this.metadata).build();
-                    this.middleware(this.request, this.response, this.nextSpy)
-                        .catch((er: any) => console.error(er));
-                });
-
-                after(() => {
-                    this.deserializeStub.reset();
-                    restore(Test.prototype.get);
-                    restore(FilterService.prototype.invokeMethod);
-                });
-
-                it("should create middleware", () => {
-                    expect(this.middleware).to.be.a("function").and.length(3);
-                });
-
-                it("should invoke middleware with some parameters", () => {
-                    this.invokeMethodStub.should.have.been.calledWithExactly(
-                        Sinon.match.func,
-                        undefined,
-                        Sinon.match.instanceOf(FakeRequest),
-                        Sinon.match.instanceOf(FakeResponse)
-                    );
-                });
-
-                it("should call middleware with some parameters", () => {
-                    this.getStub.should.have.been.calledWithExactly({request: "body"});
-                });
-
-                it("should call next spy", () =>
-                    this.nextSpy.should.have.been.calledOnce
-                );
-
-                it("shouldn't call next spy with args", () =>
-                    this.nextSpy.should.not.have.been.calledWith(Sinon.match.instanceOf(Error))
-                );
-
-                it("should store data", () => {
-                    expect(this.request.getStoredData()).to.deep.eq({response: "body"});
-                });
-            });
-
-            describe("from Endpoint with required params", () => {
-
-                before(() => {
-                    this.response = new FakeResponse();
-                    this.request = new FakeRequest();
-                    this.nextSpy = Sinon.spy();
-                    this.getStub = Sinon.stub(Test.prototype, "get").returns(undefined);
-
-                    this.metadata = {
-                        type: "controller",
-                        injectable: true,
-                        nextFunction: false,
-                        errorParam: false,
-                        target: Test,
-                        methodClassName: "get",
-                        services: [{
-                            service: PathParamsFilter,
-                            name: "PathParamsFilter",
-                            required: true,
-                            expression: "required",
-                            isValidRequiredValue: () => false
-                        }],
-                        instance: new Test
-                    };
-
-                    this.invokeMethodStub = Sinon.stub(FilterService.prototype, "invokeMethod").returns(undefined);
-
-                    this.middleware = new HandlerBuilder(this.metadata).build();
-                    this.middleware(this.request, this.response, this.nextSpy)
-                        .catch((er: any) => console.error(er));
-                });
-
-                after(() => {
-                    restore(Test.prototype.get);
-                    restore(FilterService.prototype.invokeMethod);
-                });
-
-                it("should create middleware", () => {
-                    expect(this.middleware).to.be.a("function").and.length(3);
-                });
-
-                it("should invoke middleware with some parameters", () => {
-                    this.invokeMethodStub.should.have.been.calledWithExactly(
-                        Sinon.match.func,
-                        "required",
-                        Sinon.match.instanceOf(FakeRequest),
-                        Sinon.match.instanceOf(FakeResponse)
-                    );
-                });
-
-                it("should call middleware with some parameters", () => {
-                    this.getStub.should.not.have.been.called;
-                });
-
-                it("should call next spy", () =>
-                    this.nextSpy.should.have.been.calledOnce
-                );
-
-                it("should call next spy with Error", () =>
-                    this.nextSpy.should.have.been.calledWith(Sinon.match.instanceOf(RequiredParamError))
-                );
-            });
-
-            describe("from Middleware", () => {
-
-                before(() => {
-                    this.response = new FakeResponse();
-                    this.request = new FakeRequest();
-                    this.nextSpy = Sinon.spy();
-                    this.useStub = Sinon.stub(Test.prototype, "use").returns({response: "body"});
-                    stub(MiddlewareRegistry.get).returns({instance: new Test});
-
-                    this.metadata = {
-                        type: "middleware",
-                        injectable: true,
-                        nextFunction: false,
-                        errorParam: false,
-                        target: Test,
-                        methodClassName: "use",
-                        services: [{service: PathParamsFilter, isValidRequiredValue: () => true}]
-                    };
-
-                    this.invokeMethodStub = Sinon.stub(FilterService.prototype, "invokeMethod").returns({request: "body"});
-
-                    this.middleware = new HandlerBuilder(this.metadata).build();
-                    this.middleware(this.request, this.response, this.nextSpy)
-                        .catch((er: any) => console.error(er));
-                });
-
-                after(() => {
-                    (Test.prototype.use as any).restore();
-                    (FilterService.prototype.invokeMethod as any).restore();
-                });
-
-                it("should create middleware", () => {
-                    expect(this.middleware).to.be.a("function").and.length(3);
-                });
-
-                it("should invoke middleware with some parameters", () => {
-                    this.invokeMethodStub.should.have.been.calledWithExactly(
-                        Sinon.match.func,
-                        undefined,
-                        Sinon.match.instanceOf(FakeRequest),
-                        Sinon.match.instanceOf(FakeResponse)
-                    );
-                });
-
-                it("should call middleware with some parameters", () => {
-                    this.useStub.should.have.been.calledWithExactly({request: "body"});
-                });
-
-                it("should call next spy", () =>
-                    this.nextSpy.should.have.been.calledOnce
-                );
-
-                it("shouldn't call next spy with args", () =>
-                    this.nextSpy.should.not.have.been.calledWith(Sinon.match.instanceOf(Error))
-                );
-
-                it("should store data", () => {
-                    expect(this.request.getStoredData()).to.deep.eq({response: "body"});
-                });
-            });
-
-            describe("from Middleware Error", () => {
-
-                before(() => {
-                    this.response = new FakeResponse();
-                    this.request = new FakeRequest();
-                    this.nextSpy = Sinon.spy();
-                    this.useStub = Sinon.stub(Test.prototype, "use").returns({response: "body"});
-                    stub(MiddlewareRegistry.get).returns({instance: new Test});
-
-                    this.metadata = {
-                        type: "middleware",
-                        injectable: true,
-                        nextFunction: false,
-                        errorParam: true,
-                        target: Test,
-                        methodClassName: "use",
-                        services: [
-                            {service: EXPRESS_ERR, useConverter: false, name: "err", isValidRequiredValue: () => true},
-                            {service: PathParamsFilter, isValidRequiredValue: () => true},
-                            {
-                                service: ENDPOINT_INFO,
-                                useConverter: false,
-                                name: "endpointInfo",
-                                isValidRequiredValue: () => true
-                            },
-                            {
-                                service: RESPONSE_DATA,
-                                useConverter: false,
-                                name: "responseData",
-                                isValidRequiredValue: () => true
-                            }
-                        ]
-                    };
-
-                    this.invokeMethodStub = Sinon.stub(FilterService.prototype, "invokeMethod").returns({request: "body"});
-
-                    this.middleware = new HandlerBuilder(this.metadata).build();
-                    this.middleware(new Error(), this.request, this.response, this.nextSpy)
-                        .catch((er: any) => console.error(er));
-                });
-
-                after(() => {
-                    (Test.prototype.use as any).restore();
-                    (FilterService.prototype.invokeMethod as any).restore();
-                });
-
-                it("should create middleware", () => {
-                    expect(this.middleware).to.be.a("function").and.length(4);
-                });
-
-                it("should invoke middleware with some parameters", () => {
-                    this.invokeMethodStub.should.have.been.calledWithExactly(
-                        Sinon.match.func,
-                        undefined,
-                        Sinon.match.instanceOf(FakeRequest),
-                        Sinon.match.instanceOf(FakeResponse)
-                    );
-                });
-
-                it("should call middleware with some parameters", () => {
-                    this.useStub.should.have.been.calledWithExactly(
-                        Sinon.match.instanceOf(Error),
-                        {request: "body"},
-                        Sinon.match.instanceOf(Object),
-                        Sinon.match.instanceOf(Object)
-                    );
-                });
-
-                it("should call next spy", () =>
-                    this.nextSpy.should.have.been.calledOnce
-                );
-
-                it("shouldn't call next spy with args", () =>
-                    this.nextSpy.should.not.have.been.calledWith(Sinon.match.instanceOf(Error))
-                );
-
-                it("should store data", () => {
-                    expect(this.request.getStoredData()).to.deep.eq({response: "body"});
-                });
-            });*/
-
         });
     });
     describe("buildNext()", () => {
@@ -521,10 +145,7 @@ describe("HandlerBuilder", () => {
                 expect(this.nextStub.isCalled).to.eq(true);
             });
             it("should have called the info method", () => {
-                this.infoStub.should.have.been.calledWithExactly({tagId: "1"}, {error: undefined});
-            });
-            it("should have called the log.debug with the correct parameters", () => {
-                $logStub.debug.should.have.been.calledWithExactly("1", "[INVOKE][END  ]", "log");
+                this.infoStub.should.have.been.calledWithExactly({tagId: "1"}, {error: undefined, event: "invoke.end"});
             });
         });
 
@@ -548,6 +169,43 @@ describe("HandlerBuilder", () => {
             });
             it("should have called the log.debug with the correct parameters", () => {
                 return $logStub.debug.should.not.have.been.called;
+            });
+        });
+    });
+    describe("log", () => {
+        before(() => {
+            globalServerSettings.debug = true;
+            this.metadata = {
+                target: class Test {
+                },
+                type: "type",
+                nextFunction: false,
+                injectable: false,
+                methodClassName: "methodName"
+            };
+            this.request = {
+                id: "id",
+                log: {
+                    debug: Sinon.stub()
+                },
+                getStoredData() {
+                    return "data";
+                }
+            };
+            const handlerBuilder: any = new HandlerBuilder(this.metadata);
+            handlerBuilder.log(this.request);
+        });
+        after(() => {
+            globalServerSettings.debug = true;
+        });
+
+        it("should create a log", () => {
+            this.request.log.debug.should.be.calledWithExactly({
+                data: "data",
+                injectable: false,
+                methodName: "methodName",
+                target: "Test",
+                type: "type"
             });
         });
     });
@@ -647,10 +305,6 @@ describe("HandlerBuilder", () => {
             after(() => {
                 restore(Test.prototype.get);
             });
-            it("should have called the log method", () => {
-                this.logStub.should.have.been.calledWithExactly(this.request);
-                $logStub.debug.should.have.been.calledWithExactly("1", "[INVOKE][START]", "log");
-            });
             it("should have called the buildNext method", () => {
                 this.buildNextStub.should.have.been.calledWithExactly(this.request, this.response, this.nextSpy);
             });
@@ -712,10 +366,6 @@ describe("HandlerBuilder", () => {
 
             after(() => {
                 restore(Test.prototype.get);
-            });
-            it("should have called the log method", () => {
-                this.logStub.should.have.been.calledWithExactly(this.request);
-                $logStub.debug.should.have.been.calledWithExactly("1", "[INVOKE][START]", "log");
             });
             it("should have called the buildNext method", () => {
                 this.buildNextStub.should.have.been.calledWithExactly(this.request, this.response, this.nextSpy);
@@ -795,68 +445,6 @@ describe("HandlerBuilder", () => {
 
             it("should not store data", () => {
                 return this.request.storeData.should.not.have.been.called;
-            });
-        });
-        describe("when handler return a Circular Object", () => {
-            before(() => {
-                this.response = new FakeResponse();
-                this.request = new FakeRequest();
-                this.nextSpy = Sinon.spy();
-                this.getStub = Sinon.stub(Test.prototype, "get").returns({response: "body"});
-
-                this.metadata = {
-                    type: "controller",
-                    injectable: true,
-                    nextFunction: false,
-                    errorParam: false,
-                    target: Test,
-                    methodClassName: "get",
-                    services: [],
-                    instance: new Test
-                };
-
-                const handlerBuilder = new HandlerBuilder(this.metadata);
-                this.localsToParamsStub = Sinon.stub(handlerBuilder as any, "localsToParams").returns([]);
-
-                const circularObject = new Error("test");
-                const circularObject2 = new Error("test2");
-
-                (circularObject as any)._circ2 = circularObject2;
-                (circularObject2 as any)._circ1 = circularObject;
-
-                Object.defineProperty(handlerBuilder, "handler", {
-                    get: () => () => circularObject
-                });
-
-                (handlerBuilder as any)
-                    .invoke({
-                        response: this.response,
-                        request: this.request,
-                        next: this.nextSpy
-                    })
-                    .catch((er: any) => {
-                        this.error = er;
-                    });
-            });
-
-            after(() => {
-                restore(Test.prototype.get);
-            });
-
-            it("should call the locals method", () => {
-                return this.localsToParamsStub.should.have.been.calledOnce;
-            });
-
-            it("should call next spy", () =>
-                this.nextSpy.should.have.been.calledOnce
-            );
-
-            it("should catch an error", () => {
-                this.nextSpy.should.have.been.calledWithExactly(Sinon.match.instanceOf(Error));
-            });
-
-            it("should store data", () => {
-                expect(this.request.getStoredData()).to.be.an.instanceof(Error);
             });
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3977,9 +3977,9 @@ ts-httpexceptions@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/ts-httpexceptions/-/ts-httpexceptions-2.2.3.tgz#e9e11a08fcf51f4bc8445dbfac564af3cbb2e1b7"
 
-ts-log-debug@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ts-log-debug/-/ts-log-debug-3.0.0.tgz#3acfcc2fda75c3bab22d65a56132c2dbd1f9a996"
+ts-log-debug@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ts-log-debug/-/ts-log-debug-3.0.1.tgz#ca7bfcf6812ff3a97fdbeb8419056a188beba8f0"
   dependencies:
     colors "^1.1.0"
     date-format "^1.1.0"
@@ -4172,7 +4172,7 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@^3.0.0:
+uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Status | Migration
---|---|---
Fix | Ready | No

****

## Description
Fix some problem performance #167

Important things:
- Ts.ED have some feature like dynamic parameters injection which have a cost on the performance. This feature can't be optimized.
- Logger have big cost on the performance. This fix reduce the amount of log per request.
- I've added a logger configuration, to disable completely the log.

Pure Express benchmark
```bash
Benchmarking 127.0.0.1 (be patient)


Server Software:        
Server Hostname:        127.0.0.1
Server Port:            8080

Document Path:          /
Document Length:        11 bytes

Concurrency Level:      20
Time taken for tests:   7.908 seconds
Complete requests:      30000
Failed requests:        0
Keep-Alive requests:    30000
Total transferred:      6450000 bytes
HTML transferred:       330000 bytes
Requests per second:    3793.40 [#/sec] (mean)
Time per request:       5.272 [ms] (mean)
Time per request:       0.264 [ms] (mean, across all concurrent requests)
Transfer rate:          796.47 [Kbytes/sec] received
```
Ts.ED after with this fix:
```typescript
Server Software:        
Server Hostname:        127.0.0.1
Server Port:            8081

Document Path:          /
Document Length:        11 bytes

Concurrency Level:      20
Time taken for tests:   11.110 seconds
Complete requests:      30000
Failed requests:        0
Keep-Alive requests:    30000
Total transferred:      6450000 bytes
HTML transferred:       330000 bytes
Requests per second:    2700.25 [#/sec] (mean)
Time per request:       7.407 [ms] (mean)
Time per request:       0.370 [ms] (mean, across all concurrent requests)
Transfer rate:          566.95 [Kbytes/sec] received
```

Before fix:
```typescript
Server Software:        
Server Hostname:        127.0.0.1
Server Port:            8081

Document Path:          /
Document Length:        11 bytes

Concurrency Level:      20
Time taken for tests:   19.850 seconds
Complete requests:      30000
Failed requests:        0
Keep-Alive requests:    30000
Total transferred:      6450000 bytes
HTML transferred:       330000 bytes
Requests per second:    1511.33 [#/sec] (mean)
Time per request:       13.233 [ms] (mean)
Time per request:       0.662 [ms] (mean, across all concurrent requests)
Transfer rate:          317.32 [Kbytes/sec] received
```