### PR TITLE
feat(server): Import manually a controller

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ The default configuration is as follow:
   "httpsPort": 8000,
   "uploadDir": "${rootDir}/uploads",
   "mount": {
-    "/rest": "${rootDir}/controllers/**/*.js"
+    "/rest": "${rootDir}/controllers/**/*.ts" // support ts with ts-node then fallback to js
   },
   "componentsScan": [
     "${rootDir}/middlewares/**/*.js",
@@ -28,6 +28,7 @@ The default configuration is as follow:
 ```
 
 You can customize your configuration as follow:
+
 ```typescript
 // server.ts
 import {ServerLoader, ServerSettings} from "ts-express-decorators";
@@ -39,7 +40,8 @@ import Path = require("path");
      "/rest": "${rootDir}/controllers/current/**/*.js",
      "/rest/v1": [
         "${rootDir}/controllers/v1/users/*.js", 
-        "${rootDir}/controllers/v1/groups/*.js"
+        "${rootDir}/controllers/v1/groups/*.ts", // support ts entry
+        MyController // support manual import
      ]
    }
 })
@@ -51,6 +53,9 @@ export class Server extends ServerLoader {
 import * as Server from "./server";
 new Server.start();
 ```
+> Ts.ED support [ts-node](https://github.com/TypeStrong/ts-node). Ts extension will be replaced by a Js extension if 
+ts-node isn't the runtime.
+
 ## Options
 
 * `rootDir` &lt;string&gt;: The root directory where you build run project. By default, it's equal to `process.cwd().

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,7 @@ options in your `tsconfig.json` file.
 > **Note** : target can be set to ES2015/ES6.
 
 ### Optional
+
 You can copy this example of package.json to develop your application:
 
 ```json
@@ -50,7 +51,7 @@ You can copy this example of package.json to develop your application:
     "test": "mocha --reporter spec --check-leaks --bail test/",
     "tsc": "tsc --project tsconfig.json",
     "tsc:w": "tsc -w",
-    "start": "concurrently \"npm run tsc:w\" \"nodemon app.js --ignore *.ts\""
+    "start": "nodemon --watch '**/*.ts' --ignore 'node_modules/**/*' --exec ts-node app.ts"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "swagger-ui-express": "^2.0.0",
     "ts-node": "^3.0.2",
     "tslint": "^5.1.0",
-    "typescript": "^2.4.0"
+    "typescript": "^2.5.0"
   },
   "directories": {
     "lib": "lib",

--- a/src/config/class/ServerSettingsProvider.ts
+++ b/src/config/class/ServerSettingsProvider.ts
@@ -143,7 +143,8 @@ export class ServerSettingsProvider implements IServerSettings {
 
 
     /**
-     *
+     * This attribut is deprecated.
+     * @deprecated
      * @returns {string}
      */
     get endpointUrl(): string {
@@ -155,6 +156,7 @@ export class ServerSettingsProvider implements IServerSettings {
      * @param value
      */
     set endpointUrl(value: string) {
+        console.warn("The endpointUrl option is deprecated. Use the mount option instead of. See https://goo.gl/6MPr6q.");
         this.map.set("endpointUrl", value);
     }
 
@@ -171,6 +173,7 @@ export class ServerSettingsProvider implements IServerSettings {
      * @param value
      */
     set endpoint(value: string) {
+        console.warn("The endpoint option is deprecated. Use the mount option instead of. See https://goo.gl/6MPr6q.");
         this.map.set("endpointUrl", value);
     }
 

--- a/src/config/interfaces/IServerSettings.ts
+++ b/src/config/interfaces/IServerSettings.ts
@@ -7,7 +7,7 @@ import * as Https from "https";
 import {Env} from "../../core/interfaces";
 
 export interface IServerMountDirectories {
-    [endpoint: string]: string | string[];
+    [endpoint: string]: any | string | (any | string)[];
 }
 
 export interface ILoggerSettings {

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -38,32 +38,63 @@ export function getClassOrSymbol(target: any): any {
  * @returns {boolean}
  */
 export function isPrimitiveOrPrimitiveClass(target: any): boolean {
-
-    const isPrimitive = ["string", "boolean", "number"].indexOf(typeof target);
-
-    if (isPrimitive > -1) {
-        return true;
-    }
-
-    return target instanceof String
-        || target === String
-        || target instanceof Number
-        || target === Number
-        || target instanceof Boolean
-        || target === Boolean;
+    return isString(target)
+        || isNumber(target)
+        || isBoolean(target);
 }
 
+/**
+ *
+ * @param target
+ * @returns {"string" | "number" | "boolean" | "any"}
+ */
 export function primitiveOf(target: any): "string" | "number" | "boolean" | "any" {
-    if (target instanceof String || target === String) {
+    if (isString(target)) {
         return "string";
     }
-    if (target instanceof Number || target === Number) {
+    if (isNumber(target)) {
         return "number";
     }
-    if (target instanceof Boolean || target === Boolean) {
+    if (isBoolean(target)) {
         return "boolean";
     }
     return "any";
+}
+
+/**
+ *
+ * @param target
+ * @returns {boolean}
+ */
+export function isString(target: any): boolean {
+    return typeof target === "string" || target instanceof String || target === String;
+}
+
+/**
+ *
+ * @param target
+ * @returns {boolean}
+ */
+export function isNumber(target: any): boolean {
+    return typeof target === "number" || target instanceof Number || target === Number;
+}
+
+/**
+ *
+ * @param target
+ * @returns {boolean}
+ */
+export function isBoolean(target: any): boolean {
+    return typeof target === "boolean" || target instanceof Boolean || target === Boolean;
+}
+
+/**
+ *
+ * @param target
+ * @returns {Boolean}
+ */
+export function isArray(target: any): boolean {
+    return Array.isArray(target);
 }
 
 /**
@@ -75,7 +106,7 @@ export function isArrayOrArrayClass(target: any): boolean {
     if (target === Array) {
         return true;
     }
-    return Object.prototype.toString.call(target) === "[object Array]";
+    return isArray(target);
 }
 
 /**
@@ -139,7 +170,6 @@ export function isEmpty(value: any): boolean {
  * Get object name
  */
 export const nameOf = (obj: any): string => {
-
     switch (typeof obj) {
         default:
             return "" + obj;
@@ -148,7 +178,6 @@ export const nameOf = (obj: any): string => {
         case "function":
             return nameOfClass(obj);
     }
-
 };
 
 /**
@@ -245,14 +274,29 @@ export function deepExtends(out: any, obj: any, reducers: { [key: string]: (coll
     return out;
 }
 
+/**
+ *
+ * @param target
+ * @returns {boolean}
+ */
 export function isPromise(target: any): boolean {
     return target === Promise || target instanceof Promise;
 }
 
+/**
+ *
+ * @param target
+ * @returns {any}
+ */
 export function getInheritedClass(target: any): any {
     return Object.getPrototypeOf(target);
 }
 
+/**
+ *
+ * @param {any[]} args
+ * @returns {"parameter" | "property" | "method" | "class"}
+ */
 export function getDecoratorType(args: any[]): "parameter" | "property" | "method" | "class" {
     const [, propertyKey, descriptor] = args;
 
@@ -266,18 +310,35 @@ export function getDecoratorType(args: any[]): "parameter" | "property" | "metho
     return (descriptor && descriptor.value) ? "method" : "class";
 }
 
+/**
+ *
+ * @param target
+ * @param {string} propertyKey
+ * @returns {PropertyDescriptor}
+ */
 export function descriptorOf(target: any, propertyKey: string): PropertyDescriptor {
-    return Object.getOwnPropertyDescriptor(target && target.prototype || target, propertyKey);
+    return Object.getOwnPropertyDescriptor(target && target.prototype || target, propertyKey)!;
 }
 
+/**
+ *
+ * @param target
+ * @param {string} propertyKey
+ * @returns {DecoratorParameters}
+ */
 export function decoratorArgs(target: any, propertyKey: string): DecoratorParameters {
     return [
         target,
         propertyKey,
-        descriptorOf(target, propertyKey)
+        descriptorOf(target, propertyKey)!
     ];
 }
 
+/**
+ *
+ * @param target
+ * @returns {Array}
+ */
 export function ancestorsOf(target: any) {
     const classes = [];
 
@@ -291,6 +352,12 @@ export function ancestorsOf(target: any) {
     return classes;
 }
 
+/**
+ *
+ * @param target
+ * @param {string} name
+ * @param {Function} callback
+ */
 export function applyBefore(target: any, name: string, callback: Function) {
     const original = target[name];
     target[name] = function (...args: any[]) {

--- a/src/di/decorators/inject.ts
+++ b/src/di/decorators/inject.ts
@@ -5,6 +5,7 @@ import {Metadata} from "../../core/class/Metadata";
 /** */
 import {Type} from "../../core/interfaces";
 import {InjectorService} from "../services/InjectorService";
+import {descriptorOf} from "../../core/utils";
 
 export function Inject(symbol?: any): Function {
 
@@ -23,7 +24,7 @@ export function Inject(symbol?: any): Function {
             // descriptor and don't overwrite what another decorator might have done to the descriptor.
             /* istanbul ignore next */
             if (descriptor === undefined) {
-                descriptor = Object.getOwnPropertyDescriptor(target, targetKey);
+                descriptor = descriptorOf(target, targetKey);
             }
 
             const originalMethod = descriptor.value;

--- a/src/server/components/ServerLoader.ts
+++ b/src/server/components/ServerLoader.ts
@@ -363,7 +363,7 @@ export abstract class ServerLoader implements IServerLifecycle {
      * @param endpoint
      * @returns {ServerLoader}
      */
-    @Deprecated("ServerLoader.setEndpoint() is deprecated. Use ServerLoader.mount() instead of.")
+    @Deprecated("ServerLoader.setEndpoint() is deprecated. Use ServerLoader.mount() instead of. See https://goo.gl/6MPr6q.")
     /* istanbul ignore next */
     public setEndpoint(endpoint: string): ServerLoader {
 
@@ -426,24 +426,13 @@ export abstract class ServerLoader implements IServerLifecycle {
         return this;
     }
 
-    /**
-     *
-     * @param {string} file
-     * @returns {any}
-     */
-    static file(file: string): string {
-        if (!require.extensions[".ts"]) {
-            file = file.replace(".ts", ".js");
-        }
-        return file;
-    }
 
     /**
      * Add classes to the components list
      * @param classes
      * @param options
      */
-    protected addComponents(classes: any, options: { [key: string]: any } = {}): void {
+    public addComponents(classes: any | any[], options: Partial<IComponentScanned> = {}): ServerLoader {
         classes = Object
             .keys(classes)
             .map((key) => classes[key])
@@ -456,6 +445,30 @@ export abstract class ServerLoader implements IServerLifecycle {
         this._components = (this._components || [])
             .concat([components])
             .filter(o => !!o);
+
+        return this;
+    }
+
+    /**
+     * Add classes decorated by `@Controller()` to components container.
+     *
+     * ### Example
+     *
+     * ```typescript
+     * @Controller('/ctrl')
+     * class MyController{
+     * }
+     *
+     * new ServerLoader().addControllers('/rest', [MyController])
+     * ```
+     * ?> If the MyController class isn't decorated, the class will be ignored.
+     *
+     * @param {string} endpoint
+     * @param {any[]} controllers
+     * @returns {ServerLoader}
+     */
+    public addControllers(endpoint: string, controllers: any[]) {
+        return this.addComponents(controllers, {endpoint});
     }
 
     /**
@@ -484,7 +497,7 @@ export abstract class ServerLoader implements IServerLifecycle {
         } else if (isString(path)) {
             this.scan(path, endpoint);
         } else if (isClass(path)) {
-            this.addComponents([path], {endpoint});
+            this.addControllers(endpoint, [path]);
         }
 
         return this;
@@ -625,5 +638,17 @@ export abstract class ServerLoader implements IServerLifecycle {
      */
     get httpsServer(): Https.Server {
         return this._httpsServer;
+    }
+
+    /**
+     *
+     * @param {string} file
+     * @returns {any}
+     */
+    static file(file: string): string {
+        if (!require.extensions[".ts"]) {
+            file = file.replace(".ts", ".js");
+        }
+        return file;
     }
 }

--- a/src/server/interfaces/IComponentScanned.ts
+++ b/src/server/interfaces/IComponentScanned.ts
@@ -3,7 +3,6 @@
  */
 /** */
 export interface IComponentScanned {
-    file: string;
     endpoint: string;
     classes: { [key: string]: any };
 }

--- a/src/server/interfaces/IComponentScanned.ts
+++ b/src/server/interfaces/IComponentScanned.ts
@@ -5,4 +5,6 @@
 export interface IComponentScanned {
     endpoint: string;
     classes: { [key: string]: any };
+
+    [key: string]: any;
 }

--- a/test/integration/app/app.ts
+++ b/test/integration/app/app.ts
@@ -5,6 +5,7 @@ import "../../../src/swagger";
 import "../../../src/ajv";
 import TestAcceptMimeMiddleware from "./middlewares/acceptmime";
 import Path = require("path");
+import {RestCtrl} from "./controllers/RestCtrl";
 
 const rootDir = Path.resolve(__dirname);
 
@@ -13,8 +14,12 @@ const rootDir = Path.resolve(__dirname);
     port: 8001,
     httpsPort: 8071,
     mount: {
-        "/rest": "${rootDir}/controllers/**/**.js",
-        "/rest/v1": "${rootDir}/controllers/**/**.js"
+        "/rest": [
+            "${rootDir}/controllers/Base/**.js",
+            "${rootDir}/controllers/calendars/**.ts",
+            RestCtrl
+        ],
+        "/rest/v1": "${rootDir}/controllers/**/**.ts"
     },
 
     componentsScan: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3837,9 +3837,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.4.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.2.tgz#f8395f85d459276067c988aa41837a8f82870844"
+typescript@^2.5.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
 
 uglify-js@3.0.x:
   version "3.0.27"


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Status | Migration
---|---|---
Feature | Ready | No

****

## Description

- Add ts-node support,
- Controller can be added manually to ServerSettings.mount options,
- Upgrade to TypeScript v2.5

Closes: #172


## Usage example
Example to use your feature and to improve the documentation after merging your PR:
```
import {} from "ts-express-decorators";

@ServerSettings({
   mount: {
       "/rest": [
            "${rootDir}/controllers/Base/*.js",
            "${rootDir}/controllers/calendars/*.ts", // ts-node then fallback to .js extension
            RestCtrl // Manual import
        ],
        "/rest/v1": "${rootDir}/controllers/*.ts"
    }
})
```
> ServerLoader.mount() is also updated to support all options given in the example.
