### PR TITLE
fix(socketio): allow the possibility to have both httpPort and httpsPort.

### DIFF
--- a/src/socketio/services/SocketIOService.ts
+++ b/src/socketio/services/SocketIOService.ts
@@ -31,7 +31,8 @@ export class SocketIOService implements OnServerReady {
 
         if (httpPort) {
             this.io.attach(this.httpServer.get(), config);
-        } else if (httpsPort) {
+        }
+        if (httpsPort) {
             this.io.attach(this.httpsServer.get(), config);
         }
 

--- a/test/units/socketio/services/SocketIOService.spec.ts
+++ b/test/units/socketio/services/SocketIOService.spec.ts
@@ -39,6 +39,7 @@ describe("SocketIOService", () => {
 
             it("should call attach method", () => {
                 this.socketIOServer.attach.should.have.been.calledWithExactly("httpServer", {config: "config"});
+                this.socketIOServer.attach.should.have.been.calledWithExactly("httpsServer", {config: "config"});
             });
 
             it("should call getWebsocketServices method", () => {


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Status | Migration
---|---|---
Fix | Ready | Yes

****

## Description
Fixed a case where using both httpPort and httpsPort socket.io didn't work on the https server.

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
