### PR TITLE
feat(mvc): Add Multi route support on an Endpoint

### DIFF
--- a/docs/docs/controllers.emd
+++ b/docs/docs/controllers.emd
@@ -109,6 +109,28 @@ export class CalendarCtrl {
 }
 ```
 
+## Multiple routes (Alias)
+
+Ts.ED let you define multiple routes on the same method controller, with same verb like `GET` or `POST`, or with another
+verb like this:
+
+```typescript
+import {Controller, Get, Post, PathParams} from "@tsed/common";
+
+@Controller("/calendars")
+export class CalendarCtrl {
+
+    @Get("/:id")
+    @Get("/alias/:id")
+    @Post("/:id/complexAlias")
+    async get(
+        @PathParams("id") id: string
+    ): Promise<any> {
+        return {};
+    }    
+}
+```
+
 ## Input parameters
 
 `@PathParams` decorator provide quick access to an attribute `Express.request.params`.
@@ -139,7 +161,7 @@ to get parameters send by the client.
 `@HeaderParams` decorator provide you a quick access to the `Express.request.get()`
 
 ```typescript
-import {Controller, Get, Header, PathParams} from "@tsed/common";
+import {Controller, Get, HeaderParams, PathParams} from "@tsed/common";
 
 @Controller("/calendars")
 export class CalendarCtrl {
@@ -181,7 +203,6 @@ export class CalendarCtrl {
 }
 ```
 
-
 ## Response and Request
 
 You can use a decorator to inject `Express.Request`, `Express.Response` and
@@ -215,6 +236,28 @@ export class CalendarCtrl {
     }
 }
 ```
+
+## Router
+
+Each controller has an [Express.Router](http://expressjs.com/en/guide/routing.html) instance associated with it.
+The [ExpressRouter](/api/common/mvc/expressrouter.md) decorator is here to inject this instance to your controller.
+
+```typescript
+import {Controller, Get, ExpressRouter} from "@tsed/common";
+
+@Controller("/calendars")
+export class CalendarCtrl {
+    
+    constructor(@ExpressRouter router: ExpressRouter) {
+        router.get('/', this.myMethod)
+    }
+    
+    myMethod(req, res, next){
+        
+    }
+}
+```
+> In this case, injection on the method isn't available.
 
 ## Custom middleware
 

--- a/src/common/mvc/class/EndpointBuilder.ts
+++ b/src/common/mvc/class/EndpointBuilder.ts
@@ -37,11 +37,17 @@ export class EndpointBuilder {
      * @param middlewares
      */
     private routeMiddlewares(middlewares: any[]) {
-        if (this.endpoint.hasHttpMethod() && this.router[this.endpoint.httpMethod]) {
-            this.router[this.endpoint.httpMethod](this.endpoint.path, ...middlewares);
-        } else {
-            const args: any[] = [this.endpoint.path].concat(middlewares).filter(o => !!o);
-            this.router.use(...args);
+        this.endpoint.pathsMethods.forEach(({path, method}) => {
+            if (!!method && this.router[method]) {
+                this.router[method](path, ...middlewares);
+            } else {
+                const args: any[] = [path].concat(middlewares);
+                this.router.use(...args);
+            }
+        });
+
+        if (!this.endpoint.pathsMethods.length) {
+            this.router.use(...middlewares);
         }
     }
 

--- a/src/common/mvc/class/HandlerBuilder.ts
+++ b/src/common/mvc/class/HandlerBuilder.ts
@@ -9,6 +9,7 @@ import {IFilterPreHandler} from "../../filters/interfaces/IFilterPreHandler";
 import {CastError} from "../errors/CastError";
 import {ControllerRegistry} from "../registries/ControllerRegistry";
 import {MiddlewareRegistry} from "../registries/MiddlewareRegistry";
+import {ExpressRouter} from "../services/ExpressRouter";
 import {RouterController} from "../services/RouterController";
 import {EndpointMetadata} from "./EndpointMetadata";
 import {HandlerMetadata} from "./HandlerMetadata";
@@ -98,8 +99,9 @@ export class HandlerBuilder {
         this._rebuildHandler = provider.scope !== ProviderScope.SINGLETON;
 
         if (this._rebuildHandler || provider.instance === undefined) {
-            if (!locals.has(RouterController)) {
+            if (!locals.has(ExpressRouter)) {
                 locals.set(RouterController, new RouterController(provider.router));
+                locals.set(ExpressRouter, provider.router);
             }
 
             provider.instance = InjectorService.invoke<T>(target, locals, undefined, true);

--- a/src/common/mvc/constants/index.ts
+++ b/src/common/mvc/constants/index.ts
@@ -3,7 +3,7 @@
  * @private
  * @type {string}
  */
-export const ENDPOINT_METHODS = [
+export const EXPRESS_METHODS = [
     "all", "checkout", "connect",
     "copy", "delete", "get",
     "head", "lock", "merge",

--- a/src/common/mvc/index.ts
+++ b/src/common/mvc/index.ts
@@ -28,6 +28,7 @@ export * from "./components/SendResponseMiddleware";
 export * from "./services/ControllerService";
 export * from "./services/MiddlewareService";
 export * from "./services/RouterController";
+export * from "./services/ExpressRouter";
 export * from "./services/RouteService";
 
 // decorators

--- a/src/common/mvc/interfaces/ExpressPathMethod.ts
+++ b/src/common/mvc/interfaces/ExpressPathMethod.ts
@@ -1,0 +1,6 @@
+import {PathParamsType} from "./PathParamsType";
+
+export interface ExpressPathMethod {
+    method?: string;
+    path?: PathParamsType;
+}

--- a/src/common/mvc/services/ControllerService.ts
+++ b/src/common/mvc/services/ControllerService.ts
@@ -11,6 +11,7 @@ import {ControllerProvider} from "../class/ControllerProvider";
 import {ExpressApplication} from "../decorators";
 import {IControllerOptions} from "../interfaces";
 import {ControllerRegistry} from "../registries/ControllerRegistry";
+import {ExpressRouter} from "./ExpressRouter";
 import {RouterController} from "./RouterController";
 
 /**
@@ -91,10 +92,12 @@ export class ControllerService extends ProxyRegistry<ControllerProvider, IContro
      * @param designParamTypes
      * @returns {T}
      */
-    public invoke<T>(target: any, locals: Map<Type<any>, any> = new Map<Type<any>, any>(), designParamTypes?: any[]): T {
+    public invoke<T>(target: any, locals: Map<Type<any> | any, any> = new Map<Type<any>, any>(), designParamTypes?: any[]): T {
 
-        if (!locals.has(RouterController)) {
-            locals.set(RouterController, new RouterController(Express.Router()));
+        if (!locals.has(ExpressRouter)) {
+            const router = Express.Router();
+            locals.set(RouterController, new RouterController(router));
+            locals.set(ExpressRouter, router);
         }
 
         return this.injectorService.invoke<T>(target.provide || target, locals, designParamTypes);

--- a/src/common/mvc/services/ExpressRouter.ts
+++ b/src/common/mvc/services/ExpressRouter.ts
@@ -1,0 +1,34 @@
+import {Type} from "@tsed/core";
+import * as Express from "express";
+import {Inject} from "../../di/decorators/inject";
+
+/**
+ *
+ */
+export type ExpressRouter = Express.Router & {
+    (target: Type<any>, targetKey: string, descriptor: TypedPropertyDescriptor<Function> | number): any;
+};
+
+/**
+ * Inject the ExpressRouter (Express.Router) instance.
+ *
+ * ### Example
+ *
+ * ```typescript
+ * import {ExpressRouter, Service} from "@tsed/common";
+ *
+ * @Controller("/")
+ * export default class OtherService {
+ *    constructor(@ExpressRouter router: ExpressRouter) {}
+ * }
+ * ```
+ *
+ * @param {Type<any>} target
+ * @param {string} targetKey
+ * @param {TypedPropertyDescriptor<Function> | number} descriptor
+ * @returns {any}
+ * @decorator
+ */
+export function ExpressRouter(target: Type<any>, targetKey: string, descriptor: TypedPropertyDescriptor<Function> | number) {
+    return Inject(ExpressRouter)(target, targetKey, descriptor);
+}

--- a/src/common/mvc/services/RouteService.ts
+++ b/src/common/mvc/services/RouteService.ts
@@ -83,22 +83,23 @@ export class RouteService {
 
         ctrl.endpoints.forEach((endpoint: EndpointMetadata) => {
 
-            if (endpoint.hasHttpMethod()) {
+            endpoint.pathsMethods.forEach(({path, method}) => {
+                if (!!method) {
 
-                const className = nameOf(ctrl.provide),
-                    methodClassName = endpoint.methodClassName,
-                    parameters = ParamRegistry.getParams(ctrl.provide, endpoint.methodClassName);
+                    const className = nameOf(ctrl.provide),
+                        methodClassName = endpoint.methodClassName,
+                        parameters = ParamRegistry.getParams(ctrl.provide, endpoint.methodClassName);
 
-                routes.push({
-                    method: endpoint.httpMethod,
-                    name: `${className}.${methodClassName}()`,
-                    url: `${endpointUrl}${endpoint.path || ""}`,
-                    className,
-                    methodClassName,
-                    parameters
-                });
-
-            }
+                    routes.push({
+                        method,
+                        name: `${className}.${methodClassName}()`,
+                        url: `${endpointUrl}${path || ""}`.replace(/\/\//gi, "/"),
+                        className,
+                        methodClassName,
+                        parameters
+                    });
+                }
+            });
         });
     };
 

--- a/src/common/mvc/services/RouterController.ts
+++ b/src/common/mvc/services/RouterController.ts
@@ -2,6 +2,7 @@ import * as Express from "express";
 
 /**
  * RouteController give the express Router use by the decorated controller.
+ * @deprecated Use ExpressRouter insteadof.
  */
 export class RouterController {
 
@@ -11,6 +12,7 @@ export class RouterController {
 
     /**
      * Return the Express.Router.
+     * @deprecated Use ExpressRouter insteadof.
      * @returns {Express.Router}
      */
     public getRouter(): Express.Router {

--- a/src/common/server/decorators/httpServer.ts
+++ b/src/common/server/decorators/httpServer.ts
@@ -6,7 +6,7 @@ export interface IHttpFactory {
     (target: Type<any>, targetKey: string, descriptor: TypedPropertyDescriptor<Function> | number): any;
 
     /**
-     * deprecated
+     * @deprecated
      * @returns {"https".Server}
      */
     get(): Http.Server;
@@ -28,7 +28,7 @@ export type HttpServer = Http.Server & IHttpFactory;
  * }
  * ```
  *
- * > Note: TypeScript transform and store `ExpressApplication` as `Function` type in the metadata. So to inject a factory, you must use the `@Inject(type)` decorator.
+ * > Note: TypeScript transform and store `HttpServer` as `Function` type in the metadata. So to inject a factory, you must use the `@Inject(type)` decorator.
  *
  * @param {Type<any>} target
  * @param {string} targetKey

--- a/src/common/server/decorators/httpsServer.ts
+++ b/src/common/server/decorators/httpsServer.ts
@@ -6,7 +6,7 @@ export interface IHttpsFactory {
     (target: Type<any>, targetKey: string, descriptor: TypedPropertyDescriptor<Function> | number): any;
 
     /**
-     * deprecated
+     * @deprecated
      * @returns {"https".Server}
      */
     get(): Https.Server;
@@ -28,7 +28,7 @@ export type HttpsServer = Https.Server & IHttpsFactory;
  * }
  * ```
  *
- * > Note: TypeScript transform and store `ExpressApplication` as `Function` type in the metadata. So to inject a factory, you must use the `@Inject(type)` decorator.
+ * > Note: TypeScript transform and store `HttpsServer` as `Function` type in the metadata. So to inject a factory, you must use the `@Inject(type)` decorator.
  *
  * @param {Type<any>} target
  * @param {string} targetKey

--- a/src/swagger/class/OpenApiEndpointBuilder.ts
+++ b/src/swagger/class/OpenApiEndpointBuilder.ts
@@ -1,9 +1,10 @@
+import {EndpointMetadata} from "@tsed/common";
 import {deepExtends, Store} from "@tsed/core";
 import {Operation, Path, Response} from "swagger-schema-official";
-import {EndpointMetadata} from "@tsed/common";
+import {ExpressPathMethod} from "../../common/mvc/interfaces/ExpressPathMethod";
 import {toSwaggerPath} from "../utils";
-import {OpenApiParamsBuilder} from "./OpenApiParamsBuilder";
 import {OpenApiModelSchemaBuilder} from "./OpenApiModelSchemaBuilder";
+import {OpenApiParamsBuilder} from "./OpenApiParamsBuilder";
 
 /** */
 
@@ -22,13 +23,13 @@ const getOperationId = (operationId: string) => {
 export class OpenApiEndpointBuilder extends OpenApiModelSchemaBuilder {
     private _paths: { [pathName: string]: Path } = {};
 
-    constructor(private endpoint: EndpointMetadata, private endpointUrl: string) {
+    constructor(private endpoint: EndpointMetadata, private endpointUrl: string, private pathMethod: ExpressPathMethod) {
         super(endpoint.target);
     }
 
     build(): this {
 
-        const openAPIPath = ("" + toSwaggerPath(`${this.endpointUrl}${this.endpoint.path || ""}`)).trim();
+        const openAPIPath = toSwaggerPath(this.endpointUrl, this.pathMethod.path);
         const produces = this.endpoint.get("produces") || [];
         const consumes = this.endpoint.get("consumes") || [];
         const responses = this.endpoint.get("responses") || {};
@@ -57,7 +58,7 @@ export class OpenApiEndpointBuilder extends OpenApiModelSchemaBuilder {
 
         deepExtends(operation, this.endpoint.get("operation") || {});
 
-        path[this.endpoint.httpMethod] = operation;
+        path[this.pathMethod.method!] = operation;
 
         responses[this.endpoint.get("statusCode") || "200"] = {description: "Success"};
 

--- a/src/swagger/services/SwaggerService.ts
+++ b/src/swagger/services/SwaggerService.ts
@@ -1,12 +1,17 @@
+import {
+    ControllerProvider,
+    ControllerService,
+    EndpointMetadata,
+    ExpressApplication,
+    ServerSettingsService,
+    Service
+} from "@tsed/common";
 import {deepExtends, nameOf, Store} from "@tsed/core";
 import * as Express from "express";
 import * as Fs from "fs";
 import * as PathUtils from "path";
 import {Info, Schema, Spec, Tag} from "swagger-schema-official";
 import {$log} from "ts-log-debug";
-import {
-    ServerSettingsService, Service, ControllerProvider, EndpointMetadata, ExpressApplication, ControllerService
-} from "@tsed/common";
 import {OpenApiEndpointBuilder} from "../class/OpenApiEndpointBuilder";
 import {ISwaggerPaths, ISwaggerSettings} from "../interfaces";
 import {getReducers} from "../utils";
@@ -172,14 +177,16 @@ export class SwaggerService {
             );
 
         ctrl.endpoints.forEach((endpoint: EndpointMetadata) => {
+            endpoint.pathsMethods.forEach((pathMethod) => {
+                /* istanbul ignore else */
+                if (!!pathMethod.method) {
+                    const builder = new OpenApiEndpointBuilder(endpoint, endpointUrl, pathMethod)
+                        .build();
 
-            /* istanbul ignore else */
-            if (endpoint.hasHttpMethod()) {
-                const builder = new OpenApiEndpointBuilder(endpoint, endpointUrl).build();
-
-                deepExtends(paths, builder.paths);
-                deepExtends(definitions, builder.definitions);
-            }
+                    deepExtends(paths, builder.paths);
+                    deepExtends(definitions, builder.definitions);
+                }
+            });
         });
     }
 

--- a/src/swagger/utils/index.ts
+++ b/src/swagger/utils/index.ts
@@ -1,26 +1,36 @@
-import {deepExtends} from "@tsed/core";
 import {JsonSchema, PathParamsType} from "@tsed/common";
+import {deepExtends} from "@tsed/core";
 
 /** */
 
-export function toSwaggerPath(expressPath: PathParamsType): PathParamsType {
-    if (typeof expressPath === "string") {
-        let params = expressPath.match(/:[\w]+/g);
+export function toSwaggerPath(base: string, path: PathParamsType = ""): string {
 
-        let openAPIPath = expressPath;
-        if (params) {
-            let swagerParams = params.map(x => {
-                return "{" + x.replace(":", "") + "}";
-            });
-
-            openAPIPath = params.reduce((acc, el, ix) => {
-                return acc.replace(el, swagerParams[ix]);
-            }, expressPath);
-        }
-        return openAPIPath;
-    } else {
-        return expressPath;
+    if (path instanceof RegExp) {
+        path = path.toString()
+            .replace(/^\//, "")
+            .replace(/\/$/, "")
+            .replace(/\\/, "");
     }
+
+    const completePath = "" + base + path;
+
+    // if (typeof expressPath === "string") {
+    let params = completePath.match(/:[\w]+/g);
+
+    let openAPIPath = completePath;
+    if (params) {
+        let swaggerParams = params.map(x => {
+            return "{" + x.replace(":", "") + "}";
+        });
+
+        openAPIPath = params.reduce((acc, el, ix) => {
+            return acc.replace(el, swaggerParams[ix]);
+        }, completePath);
+    }
+
+    return ("" + openAPIPath)
+        .replace(/\/\//gi, "/")
+        .trim();
 }
 
 export function swaggerType(type: any): string {

--- a/test/integration/app/app.ts
+++ b/test/integration/app/app.ts
@@ -1,12 +1,12 @@
-import {$log} from "ts-log-debug";
-import {ServerLoader, ServerSettings} from "@tsed/common";
 import "@tsed/ajv";
+import {ServerLoader, ServerSettings} from "@tsed/common";
 import "@tsed/socketio";
 import "@tsed/swagger";
+import * as Path from "path";
+import {$log} from "ts-log-debug";
 
 import {RestCtrl} from "./controllers/RestCtrl";
 import TestAcceptMimeMiddleware from "./middlewares/acceptmime";
-import * as Path from "path";
 
 const rootDir = Path.resolve(__dirname);
 

--- a/test/integration/app/controllers/RestCtrl.ts
+++ b/test/integration/app/controllers/RestCtrl.ts
@@ -1,10 +1,12 @@
-import {Controller, Get, Render, RouteService} from "@tsed/common";
+import {Controller, ExpressRouter, Get, Render, RouteService} from "@tsed/common";
 
 @Controller("/rest")
 export class RestCtrl {
 
-    constructor(private routeService: RouteService) {
+    constructor(private routeService: RouteService, @ExpressRouter private router: ExpressRouter) {
+        /*router.get(/(test)/, (res, req) => {
 
+        });*/
     }
 
     @Get("/html")

--- a/test/units/mvc/class/EndpointBuilder.spec.ts
+++ b/test/units/mvc/class/EndpointBuilder.spec.ts
@@ -50,31 +50,63 @@ describe("EndpointBuilder", () => {
 
     describe("build()", () => {
 
-        describe("use", () => {
+        describe("with use method", () => {
 
-            before(() => {
-                this.middlewares = this.endpointBuilder.build();
+            describe("when there is no path", () => {
+                before(() => {
+                    this.router.get.reset();
+                    this.router.use.reset();
+                    this.middlewares = this.endpointBuilder.build();
+                });
+
+                it("should build middlewares", () => {
+                    expect(this.middlewares).to.be.an("array").and.have.length(3);
+                });
+
+                it("should call HandlerBuilder", () => {
+                    expect(HandlerBuilder.from.called).to.eq(true);
+                });
+
+                it("should call use method", () =>
+                    this.router.use.should.have.been.calledOnce
+                );
+
+                it("should call with args", () => {
+                    this.router.use.should.have.been.calledWithExactly(...this.middlewares);
+                });
             });
 
-            it("should build middlewares", () => {
-                expect(this.middlewares).to.be.an("array").and.have.length(3);
+            describe("when there is a path", () => {
+                before(() => {
+                    this.router.get.reset();
+                    this.router.use.reset();
+                    this.endpointMetadata.path = "/";
+                    this.middlewares = this.endpointBuilder.build();
+                });
+
+                it("should build middlewares", () => {
+                    expect(this.middlewares).to.be.an("array").and.have.length(3);
+                });
+
+                it("should call HandlerBuilder", () => {
+                    expect(HandlerBuilder.from.called).to.eq(true);
+                });
+
+                it("should call use method", () =>
+                    this.router.use.should.have.been.calledOnce
+                );
+
+                it("should call with args", () => {
+                    this.router.use.should.have.been.calledWithExactly(...["/"].concat(this.middlewares));
+                });
             });
 
-            it("should call HandlerBuilder", () => {
-                expect(HandlerBuilder.from.called).to.eq(true);
-            });
-
-            it("should call use method", () =>
-                this.router.use.should.have.been.calledOnce
-            );
-
-            it("should call with args", () => {
-                this.router.use.should.have.been.calledWithExactly(...this.middlewares);
-            });
         });
 
-        describe("get", () => {
+        describe("with get method", () => {
             before(() => {
+                this.router.get.reset();
+                this.router.use.reset();
                 this.endpointMetadata.httpMethod = "get";
                 this.endpointMetadata.path = "/";
             });

--- a/test/units/swagger/class/OpenApiEndpointBuilder.spec.ts
+++ b/test/units/swagger/class/OpenApiEndpointBuilder.spec.ts
@@ -1,5 +1,5 @@
-import {Store} from "../../../../src/core/class/Store";
 import {EndpointMetadata} from "../../../../src/common/mvc/class/EndpointMetadata";
+import {Store} from "../../../../src/core/class/Store";
 import {OpenApiEndpointBuilder} from "../../../../src/swagger/class/OpenApiEndpointBuilder";
 import {Sinon} from "../../../tools";
 
@@ -10,7 +10,11 @@ class Test {
 describe("OpenApiParamsBuilder", () => {
     before(() => {
         this.endpointMetadata = new EndpointMetadata(Test, "test");
-        this.builder = new OpenApiEndpointBuilder(this.endpointMetadata, "/test");
+        this.builder = new OpenApiEndpointBuilder(
+            this.endpointMetadata,
+            "/test",
+            {path: "/", "method": "get"}
+        );
         // this.builder.build();
     });
 


### PR DESCRIPTION
Now, the decorators `@Get`, `@Post`, `Put`, `Delete`, `@Head` can be used several times
on the same class method.

```typescript
@Controller("/")
export MyCtrl {

  @Get("/route1")
  @Get("/route2")
  async myMethod() {
     return {};
  }
}
```
It useful when you need to create alias route on the same method.

- Add ExpressRouter decorator (inject Express.Router instance on a controller).
- Deprecate RouterController (use ExpressRouter instead of).
- Deprecate EndpointMetadata.httpMethod, EndpointMetadata.hasHttpMethod and EndpointMetadata.path.
- Fix Regex support on route.

Closes: #255
