### PR TITLE
fix(mongoose): Filter _id on generated Schema

### DIFF
--- a/src/mongoose/utils/buildMongooseSchema.ts
+++ b/src/mongoose/utils/buildMongooseSchema.ts
@@ -1,6 +1,8 @@
 import {JsonSchemesRegistry, PropertyMetadata, PropertyRegistry} from "@tsed/common";
 import * as mongoose from "mongoose";
 
+const MONGOOSE_RESERVED_KEYS = ["_id"];
+
 const clean = (src: any) => Object
     .keys(src)
     .reduce((obj: any, k: any) => {
@@ -42,6 +44,11 @@ export function buildMongooseSchema(target: any): mongoose.SchemaDefinition {
 
     if (properties) {
         properties.forEach((propertyMetadata: PropertyMetadata, propertyKey: string) => {
+
+            if (MONGOOSE_RESERVED_KEYS.indexOf(propertyKey) > -1) {
+                return;
+            }
+
             let definition = {
                 required: propertyMetadata.required
             };

--- a/test/units/mongoose/utils/buildMongooseSchema.spec.ts
+++ b/test/units/mongoose/utils/buildMongooseSchema.spec.ts
@@ -103,6 +103,7 @@ describe("buildMongooseSchema", () => {
 
                 const map = new Map();
                 map.set("test", this.propertyMetadata);
+                map.set("_id", {});
 
                 const map2 = new Map();
                 map2.set("test2", {
@@ -152,6 +153,10 @@ describe("buildMongooseSchema", () => {
                         ]
                     }
                 });
+            });
+
+            it("should not have an _id", () => {
+                expect(this.result._id).to.eq(undefined);
             });
         });
 


### PR DESCRIPTION
_id is a reserved key for mongoose but not for the JsonSchema.
Now the _id is filtered when JsonSchema is converted to a mongoose Schema.

Closes: #280
