### PR TITLE
Solving tsc warnings on docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -240,7 +240,7 @@ export class CalendarCtrl {
     async post(
         @Required() @BodyParams("calendar") calendar: Calendar
     ): Promise<Calendar> {
-        return new Promise((resolve: Function, reject: Function) => {
+        return new Promise<Calendar>((resolve: Function, reject: Function) => {
             calendar.id = "1";
             resolve(calendar);
         });
@@ -248,7 +248,7 @@ export class CalendarCtrl {
     
     @Delete("/")
     @Authenticated()
-    async post(
+    async deleteItem(
         @BodyParams("calendar.id") @Required() id: string 
     ): Promise<Calendar> {
         return {id, name: "calendar"};


### PR DESCRIPTION
tsc was generating warnings about two functions being called the same (post) and about the new promise without type trying to initialize it to an empty object

## Informations

Type | Status | Migration
---|---|---
Doc| Ready | No

****

## Description
By copying and pasting the controller, tsc is showing warnings, solved with this commit.
