### PR TITLE
fix(typescript): Fix an issue where the .d.ts file cant be found

### DIFF
--- a/src/common/di/class/Providers.ts
+++ b/src/common/di/class/Providers.ts
@@ -1,5 +1,4 @@
-import {Registry, Type} from "@tsed/core";
-import {RegistryKey} from "../../../core/class/Registry";
+import {Registry, Type, RegistryKey} from "@tsed/core";
 import {IProvider, TypedProvidersRegistry} from "../interfaces";
 import {RegistrySettings} from "../interfaces/RegistrySettings";
 import {Provider} from "./Provider";


### PR DESCRIPTION
fix the following error message throwing on my CI:

```
node_modules/@tsed/common/lib/di/class/Providers.d.ts(2,29): error TS2307: Cannot find module '../../../core/class/Registry'.
```

this bug was introduced somewhere above version `4.12.4`