### PR TITLE
fix(mvc): Fix override middleware decorator

### DIFF
--- a/src/common/mvc/class/HandlerMetadata.ts
+++ b/src/common/mvc/class/HandlerMetadata.ts
@@ -1,4 +1,4 @@
-import {NotEnumerable} from "@tsed/core";
+import {NotEnumerable, Store} from "@tsed/core";
 import {ProviderType} from "../../di/interfaces/ProviderType";
 import {ProviderRegistry} from "../../di/registries/ProviderRegistry";
 import {ParamMetadata} from "../../filters/class/ParamMetadata";
@@ -57,7 +57,7 @@ export class HandlerMetadata {
 
             if (provider.type === ProviderType.MIDDLEWARE) {
                 this._type = "middleware";
-                this._errorParam = provider.store.get("middlewareType") === MiddlewareType.ERROR;
+                this._errorParam = Store.from(provider.provide).get("middlewareType") === MiddlewareType.ERROR;
                 this._methodClassName = "use";
                 this._useClass = target = provider.useClass;
             }

--- a/test/units/mvc/class/HandlerMetadata.spec.ts
+++ b/test/units/mvc/class/HandlerMetadata.spec.ts
@@ -1,3 +1,4 @@
+import {Store} from "@tsed/core";
 import {ControllerRegistry, ParamRegistry, ProviderRegistry, ProviderType} from "../../../../src/common";
 import {HandlerMetadata} from "../../../../src/common/mvc/class/HandlerMetadata";
 import {MiddlewareType} from "../../../../src/common/mvc/interfaces";
@@ -220,14 +221,12 @@ describe("HandlerMetadata", () => {
             this.hasNextFunctionStub = Sinon.stub(ParamRegistry, "hasNextFunction").returns(true);
             this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(true);
             this.providerGetStub = Sinon.stub(ProviderRegistry, "get").returns({
+                provide: getClass(Test),
                 useClass: getClass(Test),
-                type: ProviderType.MIDDLEWARE,
-                store: {
-                    get() {
-                        return MiddlewareType.MIDDLEWARE;
-                    }
-                }
+                type: ProviderType.MIDDLEWARE
             });
+
+            Store.from(Test).set("middlewareType", MiddlewareType.MIDDLEWARE);
             this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
 
             this.handlerMetadata = new HandlerMetadata(Test);
@@ -276,14 +275,13 @@ describe("HandlerMetadata", () => {
             this.hasNextFunctionStub = Sinon.stub(ParamRegistry, "hasNextFunction").returns(false);
             this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(true);
             this.providerGetStub = Sinon.stub(ProviderRegistry, "get").returns({
+                provide: getClass(Test),
                 useClass: getClass(Test),
-                type: ProviderType.MIDDLEWARE,
-                store: {
-                    get() {
-                        return MiddlewareType.MIDDLEWARE;
-                    }
-                }
+                type: ProviderType.MIDDLEWARE
             });
+
+            Store.from(Test).set("middlewareType", MiddlewareType.MIDDLEWARE);
+
             this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
 
             this.handlerMetadata = new HandlerMetadata(Test);
@@ -332,14 +330,13 @@ describe("HandlerMetadata", () => {
             this.hasNextFunctionStub = Sinon.stub(ParamRegistry, "hasNextFunction").returns(true);
             this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(true);
             this.providerGetStub = Sinon.stub(ProviderRegistry, "get").returns({
+                provide: getClass(Test),
                 useClass: getClass(Test),
-                type: ProviderType.MIDDLEWARE,
-                store: {
-                    get() {
-                        return MiddlewareType.ERROR;
-                    }
-                }
+                type: ProviderType.MIDDLEWARE
             });
+
+            Store.from(Test).set("middlewareType", MiddlewareType.ERROR);
+
             this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
 
             this.handlerMetadata = new HandlerMetadata(Test);
@@ -387,14 +384,13 @@ describe("HandlerMetadata", () => {
             this.hasNextFunctionStub = Sinon.stub(ParamRegistry, "hasNextFunction").returns(false);
             this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(true);
             this.providerGetStub = Sinon.stub(ProviderRegistry, "get").returns({
+                provide: getClass(Test),
                 useClass: getClass(Test2),
-                type: ProviderType.MIDDLEWARE,
-                store: {
-                    get() {
-                        return MiddlewareType.ERROR;
-                    }
-                }
+                type: ProviderType.MIDDLEWARE
             });
+
+            Store.from(Test).set("middlewareType", MiddlewareType.ERROR);
+
             this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
 
             this.handlerMetadata = new HandlerMetadata(Test2);


### PR DESCRIPTION
Fix problem when a middleware error is override.
Type information is lost in this case.

Closes: #320
