### PR TITLE
fix(swagger): Restore spec generation.

### DIFF
--- a/docs/tutorials/swagger.emd
+++ b/docs/tutorials/swagger.emd
@@ -45,7 +45,8 @@ path | `/api-doc` |  The url subpath to access to the documentation.
 cssPath | `${rootDir}/spec/style.css` | The path to the CSS file.
 showExplorer | `true` | Display the search field in the navbar.
 spec | `{swagger: "2.0"}` | The default information spec.
-specPath | `${rootDir}/spec/swagger.json` | The path to the swagger.json. This file will be written at the first server starting if it doesn't exist. The data will me merge with the collected data via annotation.
+specPath | `${rootDir}/spec/swagger.base.json` | Load the base spec documentation from the specified path.
+outFile | `${rootDir}/spec/swagger.json` | Write the `swagger.json` spec documentation on the specified path.
 
 ## Decorators
 

--- a/src/swagger/interfaces/ISwaggerSettings.ts
+++ b/src/swagger/interfaces/ISwaggerSettings.ts
@@ -20,6 +20,7 @@ export interface ISwaggerSettings {
     options?: any;
     showExplorer?: boolean;
     specPath?: string;
+    outFile?: string;
     spec?: {
         swagger?: string;
         info?: Info;

--- a/src/swagger/readme.md
+++ b/src/swagger/readme.md
@@ -45,8 +45,8 @@ path | `/api-doc` |  The url subpath to access to the documentation.
 cssPath | `${rootDir}/spec/style.css` | The path to the CSS file.
 showExplorer | `true` | Display the search field in the navbar.
 spec | `{swagger: "2.0"}` | The default information spec.
-specPath | `${rootDir}/spec/swagger.json` | The path to the swagger.json. This file will be written at the first server starting if it doesn't exist. The data will me merge with the collected data via annotation.
-
+specPath | `${rootDir}/spec/swagger.base.json` | Load the base spec documentation from the specified path.
+outFile | `${rootDir}/spec/swagger.json` | Write the `swagger.json` spec documentation on the specified path.
 
 
 ## Examples

--- a/src/swagger/services/SwaggerService.ts
+++ b/src/swagger/services/SwaggerService.ts
@@ -53,6 +53,10 @@ export class SwaggerService {
 
             this.expressApplication.use(path, this.middleware().serve);
             this.expressApplication.get(path, this.middleware().setup(spec, conf.showExplorer, conf.options || {}, cssContent));
+
+            if (conf.outFile) {
+                Fs.writeFileSync(conf.outFile, JSON.stringify(spec, null, 2));
+            }
         }
 
     }

--- a/test/units/swagger/services/SwaggerService.spec.ts
+++ b/test/units/swagger/services/SwaggerService.spec.ts
@@ -116,6 +116,7 @@ describe("SwaggerService", () => {
                 this.getStub = Sinon.stub(this.settingsService, "get").returns({
                     path: "/path",
                     specPath: "/path/to/spec",
+                    outFile: "/path/to/specOut",
                     showExplorer: true,
                     options: {options: "true"}
                 });
@@ -149,6 +150,10 @@ describe("SwaggerService", () => {
                 this.expressApplication.get.should.be.calledWithExactly("/path/swagger.json", Sinon.match.func);
                 this.expressApplication.use.should.be.calledWithExactly("/path", Sinon.match.func);
                 this.expressApplication.get.should.be.calledWithExactly("/path", {setup: "setup"});
+            });
+            it("should write spec.json", () => {
+                this.writeFileSyncStub.should.be.calledOnce;
+                this.writeFileSyncStub.should.be.calledWithExactly("/path/to/specOut", JSON.stringify({spec: "test"}, null, 2));
             });
         });
 


### PR DESCRIPTION
- Use outFile option in swagger configuration to write the swagger.json
in a specific directory.
