### PR TITLE
chore: Refactoring Controllers registry

### DIFF
--- a/src/common/di/class/Provider.ts
+++ b/src/common/di/class/Provider.ts
@@ -106,7 +106,11 @@ export class Provider<T> implements IProvider<T> {
      * @returns {boolean}
      */
     get scope(): ProviderScope {
-        return this.store.get("scope") || globalServerSettings.controllerScope;
+        if (this.type === ProviderType.CONTROLLER) {
+            return this.store.get("scope") || globalServerSettings.controllerScope;
+        }
+
+        return this.store.get("scope");
     }
 
     /**

--- a/src/common/di/class/Providers.ts
+++ b/src/common/di/class/Providers.ts
@@ -1,4 +1,4 @@
-import {Registry, Type, RegistryKey} from "@tsed/core";
+import {Registry, RegistryKey, Type} from "@tsed/core";
 import {IProvider, TypedProvidersRegistry} from "../interfaces";
 import {RegistrySettings} from "../interfaces/RegistrySettings";
 import {Provider} from "./Provider";
@@ -41,7 +41,16 @@ export class Providers extends Registry<Provider<any>, IProvider<any>> {
      * @returns {RegistrySettings | undefined}
      */
     getRegistrySettings(target: string | RegistryKey): RegistrySettings {
-        const type: string = typeof target === "string" ? target : this.get(target)!.type;
+        let type: string = "provider";
+
+        if (typeof target === "string") {
+            type = target;
+        } else {
+            const provider = this.get(target);
+            if (provider) {
+                type = provider.type;
+            }
+        }
 
         if (this._registries.has(type)) {
             return this._registries.get(type)!;

--- a/src/common/di/interfaces/ProviderType.ts
+++ b/src/common/di/interfaces/ProviderType.ts
@@ -2,6 +2,7 @@ export enum ProviderType {
     FACTORY = "factory",
     SERVICE = "service",
     PROVIDER = "provider",
+    CONTROLLER = "controller",
     CONVERTER = "converter",
     INTERCEPTOR = "interceptor",
     FILTER = "filter",

--- a/src/common/di/interfaces/RegistrySettings.ts
+++ b/src/common/di/interfaces/RegistrySettings.ts
@@ -6,4 +6,12 @@ export interface RegistrySettings {
     registry: Registry<Provider<any>, IProvider<any>>;
     injectable: boolean;
     buildable: boolean;
+
+    /**
+     *
+     * @param target
+     * @param {Map<string | Function, any>} locals
+     * @param {any[]} designParamTypes
+     */
+    onInvoke?(target: Provider<any>, locals: Map<string | Function, any>, designParamTypes: any[]): void;
 }

--- a/src/common/di/services/InjectorService.ts
+++ b/src/common/di/services/InjectorService.ts
@@ -1,9 +1,9 @@
-import {Deprecated, Env, Metadata, nameOf, promiseTimeout, ProxyRegistry, Store, Type} from "@tsed/core";
+import {Deprecated, Env, getClass, Metadata, nameOf, promiseTimeout, ProxyRegistry, Store, Type} from "@tsed/core";
 import {$log} from "ts-log-debug";
 import {Provider} from "../class/Provider";
 import {InjectionError} from "../errors/InjectionError";
 import {InjectionScopeError} from "../errors/InjectionScopeError";
-import {IInjectableMethod, IProvider, ProviderScope, ProviderType} from "../interfaces";
+import {IInjectableMethod, IProvider, ProviderScope} from "../interfaces";
 import {
     GlobalProviders,
     ProviderRegistry,
@@ -35,6 +35,7 @@ import {
  *
  */
 export class InjectorService extends ProxyRegistry<Provider<any>, IProvider<any>> {
+
     constructor() {
         super(ProviderRegistry);
     }
@@ -60,8 +61,8 @@ export class InjectorService extends ProxyRegistry<Provider<any>, IProvider<any>
      * @param designParamTypes Optional object. List of injectable types.
      * @returns {T} The class constructed.
      */
-    public invoke<T>(target: any, locals: Map<Function, any> = new Map<Function, any>(), designParamTypes?: any[]): T {
-        return InjectorService.invoke<T>(target, locals, designParamTypes);
+    public invoke<T>(target: any, locals: Map<Function, any> = new Map<Function, any>(), designParamTypes?: any[], requiredScope: boolean = false): T {
+        return InjectorService.invoke<T>(target, locals, designParamTypes, requiredScope);
     }
 
     /**
@@ -238,80 +239,89 @@ export class InjectorService extends ProxyRegistry<Provider<any>, IProvider<any>
      * @returns {T} The class constructed.
      */
     static invoke<T>(target: any, locals: Map<string | Function, any> = new Map<Function, any>(), designParamTypes?: any[], requiredScope: boolean = false): T {
+        const {onInvoke} = GlobalProviders.getRegistrySettings(target);
+        const provider = GlobalProviders.get(target);
+        const parentScope = Store.from(target).get("scope");
 
         if (!designParamTypes) {
             designParamTypes = Metadata.getParamTypes(target);
         }
 
-        const parentScope = Store.from(target).get("scope");
-        /* istanbul ignore next */
-        const injectionFailedError = (er: any, serviceName: string) => {
-            const error = new InjectionError(target, serviceName.toString(), "injection failed");
-            (error as any).origin = er;
-            throw error;
-        };
+        if (provider && onInvoke) {
+            onInvoke(provider, locals, designParamTypes);
+        }
 
         const services = designParamTypes
-            .map((serviceType: any) => {
-                const serviceName = typeof serviceType === "function" ? nameOf(serviceType) : serviceType;
-
-                /* istanbul ignore next */
-                if (locals.has(serviceName)) {
-                    return locals.get(serviceName);
-                }
-
-                if (locals.has(serviceType)) {
-                    return locals.get(serviceType);
-                }
-
-                /* istanbul ignore next */
-                if (!ProviderRegistry.has(serviceType)) {
-                    throw new InjectionError(target, serviceName.toString());
-                }
-
-                // const settings = GlobalProviders.getRegistrySettings(serviceType);
-                const provider = ProviderRegistry.get(serviceType)!;
-
-                /* istanbul ignore next */
-                // if (!settings.injectable) {
-                //    throw new InjectionError(target, serviceName.toString(), "not injectable");
-                // }
-
-                if (provider.instance === undefined) {
-
-                    try {
-                        provider.instance = this.invoke<any>(provider.useClass, locals, undefined, requiredScope);
-                    } catch (er) {
-                        /* istanbul ignore next */
-                        throw injectionFailedError(er, serviceName);
-                    }
-                }
-
-                if (provider.scope === ProviderScope.REQUEST && provider.type !== ProviderType.FACTORY) {
-                    if (requiredScope && !parentScope) {
-                        throw new InjectionScopeError(provider.useClass, target);
-                    }
-
-                    try {
-                        return this.invoke<any>(provider.useClass, locals, undefined, requiredScope);
-                    } catch (er) {
-                        /* istanbul ignore next */
-                        throw injectionFailedError(er, serviceName);
-                    }
-                }
-
-                return this.get(serviceType);
-
-
-            });
+            .map((serviceType) =>
+                this.mapServices({
+                    serviceType,
+                    target,
+                    locals,
+                    requiredScope,
+                    parentScope
+                })
+            );
 
         return new target(...services);
     }
 
     /**
+     *
+     * @returns {any}
+     * @param options
+     */
+    private static mapServices(options: any) {
+        const {serviceType, target, locals, parentScope, requiredScope} = options;
+        const serviceName = typeof serviceType === "function" ? nameOf(serviceType) : serviceType;
+        const localService = locals.get(serviceName) || locals.get(serviceType);
+
+        if (localService) {
+            $log.debug(nameOf(target), "from cache");
+            return localService;
+        }
+
+        const provider = GlobalProviders.get(serviceType);
+
+        if (!provider) {
+            throw new InjectionError(target, serviceName.toString());
+        }
+
+        const {buildable, injectable} = GlobalProviders.getRegistrySettings(provider.type);
+        const scopeReq = provider.scope === ProviderScope.REQUEST;
+
+        if (!injectable) {
+            throw new InjectionError(target, serviceName.toString(), "not injectable");
+        }
+
+        if (!buildable || (provider.instance && !scopeReq)) {
+            return provider.instance;
+        }
+
+        if (scopeReq && requiredScope && !parentScope) {
+            $log.error("====>", nameOf(serviceName), nameOf(getClass(provider.instance)), provider, requiredScope, parentScope);
+            throw new InjectionScopeError(provider.useClass, target);
+        }
+
+        try {
+            const instance = this.invoke<any>(provider.useClass, locals, undefined, requiredScope);
+
+            if (!scopeReq) {
+                locals.set(provider.provide, instance);
+            }
+            return instance;
+        } catch (er) {
+            const error = new InjectionError(target, serviceName.toString(), "injection failed");
+            (error as any).origin = er;
+            throw error;
+        }
+    }
+
+    /**
      * Construct the service with his dependencies.
      * @param target The service to be built.
+     * @deprecated
      */
+    @Deprecated("removed feature")
     static construct<T>(target: Type<any> | symbol): T {
         const provider: Provider<any> = ProviderRegistry.get(target)!;
         return this.invoke<any>(provider.useClass);
@@ -451,7 +461,11 @@ export class InjectorService extends ProxyRegistry<Provider<any>, IProvider<any>
      */
     static async load() {
 
-        this.build();
+        // containers
+        const containers = new Map();
+        GlobalProviders.forEach((p, k) => containers.set(k, p));
+
+        this.build(containers);
         $log.debug("\x1B[1mProvider registry built\x1B[22m");
 
         return Promise.all([
@@ -462,21 +476,29 @@ export class InjectorService extends ProxyRegistry<Provider<any>, IProvider<any>
     /**
      *
      */
-    static build() {
-        GlobalProviders.forEach((provider, key) => {
-            const token = nameOf(provider.provide);
-            const settings = GlobalProviders.getRegistrySettings(key);
+    static build(container: Map<Type<any>, Provider<any>>) {
+        const locals = new Map();
 
-            if (settings.buildable) {
-                provider.instance = InjectorService.invoke(provider.useClass);
+        container
+            .forEach((provider, key) => {
+                const token = nameOf(provider.provide);
+                const settings = GlobalProviders.getRegistrySettings(key);
 
-                const useClass = nameOf(provider.useClass);
+                if (settings.buildable) {
+                    if (!locals.has(provider.provide)) {
+                        provider.instance = this.invoke(provider.useClass, locals);
+                        locals.set(provider.provide, provider.instance);
+                    }
 
-                $log.debug(nameOf(provider.provide), "built", token === useClass ? "" : `from class ${useClass}`);
-            } else {
-                $log.debug(nameOf(provider.provide), "loaded");
-            }
-        });
+                    if (provider.instance) {
+                        const useClass = nameOf(provider.useClass);
+                        $log.debug(nameOf(provider.provide), "built", token === useClass ? "" : `from class ${useClass}`);
+                    }
+
+                } else {
+                    $log.debug(nameOf(provider.provide), "loaded");
+                }
+            });
     }
 
     /**

--- a/src/common/mvc/class/ControllerBuilder.ts
+++ b/src/common/mvc/class/ControllerBuilder.ts
@@ -1,12 +1,12 @@
-import * as Express from "express";
 import {Type} from "@tsed/core";
+import * as Express from "express";
+import {IRouterOptions} from "../../config/interfaces/IRouterOptions";
 import {ControllerRegistry} from "../registries/ControllerRegistry";
 import {EndpointRegistry} from "../registries/EndpointRegistry";
 import {ControllerProvider} from "./ControllerProvider";
 
 import {EndpointBuilder} from "./EndpointBuilder";
 import {HandlerBuilder} from "./HandlerBuilder";
-import {IRouterOptions} from "../../config/interfaces/IRouterOptions";
 
 export class ControllerBuilder {
 
@@ -33,16 +33,16 @@ export class ControllerBuilder {
 
         ctrl.dependencies
             .forEach((child: Type<any>) => {
-                const ctrlMeta = ControllerRegistry.get(child);
+                const provider = ControllerRegistry.get(child) as ControllerProvider;
 
                 /* istanbul ignore next */
-                if (!ctrlMeta) {
+                if (!provider) {
                     throw new Error("Controller component not found in the ControllerRegistry");
                 }
 
-                const ctrlBuilder = new ControllerBuilder(ctrlMeta, this.defaultRoutersOptions).build();
+                const ctrlBuilder = new ControllerBuilder(provider, this.defaultRoutersOptions).build();
 
-                this.provider.router.use(ctrlMeta.path, ctrlBuilder.provider.router);
+                this.provider.router.use(provider.path, ctrlBuilder.provider.router);
             });
 
 

--- a/src/common/mvc/class/ControllerProvider.ts
+++ b/src/common/mvc/class/ControllerProvider.ts
@@ -23,11 +23,7 @@ export class ControllerProvider extends Provider<any> implements IControllerOpti
      */
     @NotEnumerable()
     private _routerOptions: IRouterOptions;
-    /**
-     * The path for the RouterController when the controller will be mounted to the Express Application.
-     */
-    @NotEnumerable()
-    private _routerPaths: string[] = [];
+
     /**
      * Controllers that depend to this controller.
      * @type {Array}
@@ -65,11 +61,6 @@ export class ControllerProvider extends Provider<any> implements IControllerOpti
      */
     set path(value: string) {
         this._path = value;
-    }
-
-
-    get routerPaths(): string[] {
-        return this._routerPaths;
     }
 
     /**
@@ -140,14 +131,6 @@ export class ControllerProvider extends Provider<any> implements IControllerOpti
         Object.keys(middlewares).forEach((key: string) => {
             concat(key, this._middlewares, middlewares);
         });
-    }
-
-    /**
-     *
-     * @param {string} path
-     */
-    public pushRouterPath(path: string) {
-        this._routerPaths.push(path);
     }
 
     /**

--- a/src/common/mvc/class/HandlerBuilder.ts
+++ b/src/common/mvc/class/HandlerBuilder.ts
@@ -8,9 +8,6 @@ import {FilterBuilder} from "../../filters/class/FilterBuilder";
 import {ParamMetadata} from "../../filters/class/ParamMetadata";
 import {IFilterPreHandler} from "../../filters/interfaces/IFilterPreHandler";
 import {CastError} from "../errors/CastError";
-import {ControllerRegistry} from "../registries/ControllerRegistry";
-import {ExpressRouter} from "../services/ExpressRouter";
-import {RouterController} from "../services/RouterController";
 import {EndpointMetadata} from "./EndpointMetadata";
 import {HandlerMetadata} from "./HandlerMetadata";
 
@@ -62,52 +59,27 @@ export class HandlerBuilder {
 
     /**
      *
+     * @param locals
      * @returns {any}
      */
-    private middlewareHandler(): Function {
+    private buildHandler<T>(locals: Map<string | Function, any> = new Map<string | Function, any>()): Function {
+
         const provider = ProviderRegistry.get(this.handlerMetadata.target);
 
         /* istanbul ignore next */
         if (!provider) {
-            throw new Error(`${nameOf(this.handlerMetadata.target)} middleware component not found in the MiddlewareRegistry`);
-        }
-
-        let instance = provider.instance;
-        this._rebuildHandler = provider.scope !== ProviderScope.SINGLETON;
-
-        if (this._rebuildHandler) {
-            instance = InjectorService.invoke(provider.useClass, undefined, undefined, true);
-        }
-
-        return instance.use.bind(instance);
-    }
-
-    /**
-     *
-     * @param locals
-     * @returns {any}
-     */
-    private endpointHandler<T>(locals: Map<string | Function, any> = new Map<string | Function, any>()): Function {
-
-        const provider = ControllerRegistry.get(this.handlerMetadata.target);
-        /* istanbul ignore next */
-        if (!provider) {
-            throw new Error("Controller component not found in the ControllerRegistry");
+            throw new Error(`${nameOf(this.handlerMetadata.target)} component not found in the ProviderRegistry`);
         }
 
         const target = provider.useClass;
+        let instance = provider.instance;
         this._rebuildHandler = provider.scope !== ProviderScope.SINGLETON;
 
-        if (this._rebuildHandler || provider.instance === undefined) {
-            if (!locals.has(ExpressRouter)) {
-                locals.set(RouterController, new RouterController(provider.router));
-                locals.set(ExpressRouter, provider.router);
-            }
-
-            provider.instance = InjectorService.invoke<T>(target, locals, undefined, true);
+        if (this._rebuildHandler || instance === undefined) {
+            instance = InjectorService.invoke<T>(target, locals, undefined, true);
         }
 
-        return provider.instance[this.handlerMetadata.methodClassName!].bind(provider.instance);
+        return instance[this.handlerMetadata.methodClassName!].bind(instance);
     }
 
     /**
@@ -124,11 +96,8 @@ export class HandlerBuilder {
                 this._handler = this.handlerMetadata.target;
                 break;
             case "middleware":
-                this._handler = this.middlewareHandler();
-                break;
-
             case "controller":
-                this._handler = this.endpointHandler();
+                this._handler = this.buildHandler();
                 break;
         }
 

--- a/src/common/mvc/class/HandlerMetadata.ts
+++ b/src/common/mvc/class/HandlerMetadata.ts
@@ -5,7 +5,6 @@ import {ParamMetadata} from "../../filters/class/ParamMetadata";
 import {EXPRESS_ERR, EXPRESS_NEXT_FN, EXPRESS_REQUEST, EXPRESS_RESPONSE} from "../../filters/constants";
 import {ParamRegistry} from "../../filters/registries/ParamRegistry";
 import {MiddlewareType} from "../interfaces";
-import {ControllerRegistry} from "../registries/ControllerRegistry";
 
 
 export class HandlerMetadata {
@@ -52,8 +51,8 @@ export class HandlerMetadata {
         let target = this._target;
 
         if (ProviderRegistry.has(this._target)) {
-
             const provider = ProviderRegistry.get(this._target)!;
+            this._type = provider.type;
 
             if (provider.type === ProviderType.MIDDLEWARE) {
                 this._type = "middleware";
@@ -61,10 +60,6 @@ export class HandlerMetadata {
                 this._methodClassName = "use";
                 this._useClass = target = provider.useClass;
             }
-        }
-
-        if (ControllerRegistry.has(this._target)) {
-            this._type = "controller";
         }
 
         if (this._methodClassName) {
@@ -78,7 +73,6 @@ export class HandlerMetadata {
             this._errorParam = handler.length === 4;
             this._nextFunction = handler.length >= 3;
         }
-
     }
 
     get type() {

--- a/src/common/mvc/decorators/class/controller.ts
+++ b/src/common/mvc/decorators/class/controller.ts
@@ -1,4 +1,5 @@
-import {Type, isArrayOrArrayClass} from "@tsed/core";
+import {registerController} from "@tsed/common";
+import {isArrayOrArrayClass, Type} from "@tsed/core";
 import {IControllerOptions} from "../../interfaces/IControllerOptions";
 import {PathParamsType} from "../../interfaces/PathParamsType";
 import {ControllerRegistry} from "../../registries/ControllerRegistry";
@@ -29,6 +30,9 @@ import {ControllerRegistry} from "../../registries/ControllerRegistry";
  */
 export function Controller(path: PathParamsType | IControllerOptions, ...dependencies: Type<any>[]): Function {
     return (target: any): void => {
+
+        registerController(target);
+
         if (typeof path === "string" || path instanceof RegExp || isArrayOrArrayClass(path)) {
             ControllerRegistry.merge(target, {path: (path as PathParamsType), dependencies});
         } else {

--- a/src/common/mvc/registries/ControllerRegistry.ts
+++ b/src/common/mvc/registries/ControllerRegistry.ts
@@ -1,5 +1,45 @@
-import {Registry} from "@tsed/core";
+import {ProviderType} from "../../di/interfaces/ProviderType";
+import {GlobalProviders} from "../../di/registries/ProviderRegistry";
 import {ControllerProvider} from "../class/ControllerProvider";
-import {IControllerOptions} from "../interfaces/IControllerOptions";
+import {ExpressRouter} from "../services/ExpressRouter";
+import {RouterController} from "../services/RouterController";
 
-export const ControllerRegistry = new Registry<ControllerProvider, IControllerOptions>(ControllerProvider);
+export const ControllerRegistry = GlobalProviders.createRegistry(ProviderType.CONTROLLER, ControllerProvider, {
+    injectable: false,
+    buildable: true,
+
+    onInvoke(provider: ControllerProvider, locals, designParamTypes) {
+        if (!locals.has(ExpressRouter)) {
+            locals.set(RouterController, new RouterController(provider.router));
+            locals.set(ExpressRouter, provider.router);
+        }
+    }
+});
+/**
+ * Add a new controller in the `ProviderRegistry`. This controller will be built when `InjectorService` will be loaded.
+ *
+ * #### Example
+ *
+ * ```typescript
+ * import {registerController, InjectorService} from "@tsed/common";
+ *
+ * export default class MyController {
+ *     constructor(){}
+ *     transform() {
+ *         return "test";
+ *     }
+ * }
+ *
+ * registerController({provide: MyController});
+ * // or
+ * registerController(MyController);
+ *
+ * InjectorService.load();
+ *
+ * const myController = InjectorService.get<MyController>(MyController);
+ * myController.getFoo(); // test
+ * ```
+ *
+ * @param provider Provider configuration.
+ */
+export const registerController = GlobalProviders.createRegisterFn(ProviderType.FILTER);

--- a/src/common/mvc/services/RouteService.ts
+++ b/src/common/mvc/services/RouteService.ts
@@ -24,47 +24,20 @@ export class RouteService {
     }
 
     /**
-     * Get all routes builded by TsExpressDecorators and mounted on Express application.
+     * Get all routes built by TsExpressDecorators and mounted on Express application.
      * @returns {IControllerRoute[]}
      */
     public getRoutes(): IControllerRoute[] {
 
         let routes: IControllerRoute[] = [];
 
-        this.controllerService.forEach((provider: ControllerProvider) => {
-            if (!provider.hasParent()) {
-
-                provider.routerPaths.forEach(path => {
-                    this.buildRoutes(routes, provider, provider.getEndpointUrl(path));
-                });
-
-
-            }
+        this.controllerService.routes.forEach((config: { route: string, provider: ControllerProvider }) => {
+            this.buildRoutes(routes, config.provider, config.route);
         });
 
         return routes;
     }
 
-    /**
-     * Sort controllers infos.
-     * @param routeA
-     * @param routeB
-     * @returns {number}
-     */
-    private sort = (routeA: IControllerRoute, routeB: IControllerRoute) => {
-
-        /* istanbul ignore next */
-        if (routeA.url > routeB.url) {
-            return 1;
-        }
-
-        /* istanbul ignore next */
-        if (routeA.url < routeB.url) {
-            return -1;
-        }
-        /* istanbul ignore next */
-        return 0;
-    };
     /**
      *
      * @param routes

--- a/src/swagger/class/OpenApiEndpointBuilder.ts
+++ b/src/swagger/class/OpenApiEndpointBuilder.ts
@@ -8,22 +8,14 @@ import {OpenApiParamsBuilder} from "./OpenApiParamsBuilder";
 
 /** */
 
-const OPERATION_IDS: any = {};
-
-const getOperationId = (operationId: string) => {
-    if (OPERATION_IDS[operationId] !== undefined) {
-        OPERATION_IDS[operationId]++;
-        operationId = operationId + "_" + OPERATION_IDS[operationId];
-    } else {
-        OPERATION_IDS[operationId] = 0;
-    }
-    return operationId;
-};
 
 export class OpenApiEndpointBuilder extends OpenApiModelSchemaBuilder {
     private _paths: { [pathName: string]: Path } = {};
 
-    constructor(private endpoint: EndpointMetadata, private endpointUrl: string, private pathMethod: ExpressPathMethod) {
+    constructor(private endpoint: EndpointMetadata,
+                private endpointUrl: string,
+                private pathMethod: ExpressPathMethod,
+                private getOperationId: Function) {
         super(endpoint.target);
     }
 
@@ -34,7 +26,8 @@ export class OpenApiEndpointBuilder extends OpenApiModelSchemaBuilder {
         const consumes = this.endpoint.get("consumes") || [];
         const responses = this.endpoint.get("responses") || {};
         const security = this.endpoint.get("security") || [];
-        const operationId = getOperationId(`${this.endpoint.targetName}.${this.endpoint.methodClassName}`);
+
+        const operationId = this.getOperationId(`${this.endpoint.targetName}.${this.endpoint.methodClassName}`);
         const openApiParamsBuilder = new OpenApiParamsBuilder(this.endpoint.target, this.endpoint.methodClassName);
 
         openApiParamsBuilder

--- a/test/integration/app/controllers/users/UserCtrl.ts
+++ b/test/integration/app/controllers/users/UserCtrl.ts
@@ -1,9 +1,9 @@
-import {Controller, Get, PathParams, Scope} from "@tsed/common";
+import {Controller, Get, PathParams, ProviderScope, Scope} from "@tsed/common";
 import {Hidden} from "../../../../../src/swagger";
 import {UserService} from "../../services/UserService";
 
 @Controller("/user")
-@Scope("request")
+@Scope(ProviderScope.REQUEST)
 @Hidden()
 export class UserCtrl {
 

--- a/test/integration/data/swagger.spec.json
+++ b/test/integration/data/swagger.spec.json
@@ -46,9 +46,6 @@
     {
       "name": "CalendarCtrl",
       "description": "Controller description"
-    },
-    {
-      "name": "FakeCtrl"
     }
   ],
   "paths": {

--- a/test/units/di/services/InjectorService.spec.ts
+++ b/test/units/di/services/InjectorService.spec.ts
@@ -1,7 +1,6 @@
-import {GlobalProviders, ProviderType} from "@tsed/common";
+import {GlobalProviders, ProviderScope, ProviderType} from "@tsed/common";
+import {Metadata, Store} from "@tsed/core";
 import {Inject, InjectorService} from "../../../../src";
-import {ProviderRegistry} from "../../../../src/common/di/registries/ProviderRegistry";
-import {Store} from "../../../../src/core/class/Store";
 import {inject} from "../../../../src/testing/inject";
 import {expect, Sinon} from "../../../tools";
 
@@ -77,12 +76,468 @@ describe("InjectorService", () => {
                 expect(myFactory.method()).to.equal("test");
             }));
         });
+
+        describe("mapServices()", () => {
+            describe("when serviceType is a string", () => {
+                before(() => {
+                    this.symbol = "ServiceName";
+
+                    const locals = new Map();
+                    locals.set(this.symbol, "ServiceInstanceName");
+                    this.result = (InjectorService as any).mapServices({
+                        serviceType: this.symbol,
+                        locals
+                    });
+                });
+
+                it("should return the service instance from the locals map", () => {
+                    expect(this.result).to.eq("ServiceInstanceName");
+                });
+            });
+
+            describe("when serviceType is a class from locals", () => {
+                before(() => {
+                    this.symbol = class Test {
+                    };
+
+                    const locals = new Map();
+                    locals.set(this.symbol, new this.symbol);
+
+                    this.result = (InjectorService as any).mapServices({
+                        serviceType: this.symbol,
+                        locals
+                    });
+                });
+
+                it("should return the service instance from the locals map", () => {
+                    expect(this.result).to.be.instanceOf(this.symbol);
+                });
+            });
+
+            describe("when serviceType is a class from registry (unknow)", () => {
+                before(() => {
+                    this.symbol = class Test {
+                    };
+
+                    const locals = new Map();
+                    this.getStub = Sinon.stub(GlobalProviders, "get").returns(undefined);
+
+                    try {
+                        this.result = (InjectorService as any).mapServices({
+                            serviceType: this.symbol,
+                            locals,
+                            target: class ServiceTest {
+                            }
+                        });
+                    } catch (er) {
+                        this.error = er;
+                    }
+                });
+
+                after(() => {
+                    this.getStub.restore();
+                });
+
+                it("should call GlobalProviders.has", () => {
+                    this.getStub.should.have.been.calledWithExactly(this.symbol);
+                });
+
+                it("should throw an error", () => {
+                    expect(this.error.message).to.eq("Service ServiceTest > Test not found.");
+                });
+            });
+
+            describe("when serviceType is a class from registry (know, buildable, instance undefined)", () => {
+                before(() => {
+                    this.symbol = class Test {
+                    };
+
+                    this.locals = new Map();
+                    this.getStub = Sinon.stub(GlobalProviders, "get").returns({
+                        instance: undefined,
+                        useClass: "useClass",
+                        type: "provider"
+                    });
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns({
+                            buildable: true,
+                            injectable: true
+                        });
+
+                    this.invokeStub = Sinon.stub(InjectorService, "invoke").returns("instance");
+
+                    this.result = (InjectorService as any).mapServices({
+                        serviceType: this.symbol,
+                        locals: this.locals,
+                        requiredScope: true,
+                        target: class ServiceTest {
+                        }
+                    });
+                });
+
+                after(() => {
+                    this.getStub.restore();
+                    this.invokeStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                });
+
+                it("should call GlobalProviders.get", () => {
+                    this.getStub.should.have.been.calledWithExactly(this.symbol);
+                });
+
+                it("should call GlobalProviders.getRegistrySettings", () => {
+                    this.getRegistrySettingsStub.should.be.calledWithExactly("provider");
+                });
+                it("should build instance and return the service", () => {
+                    this.invokeStub.should.have.been.calledWithExactly("useClass", this.locals, undefined, true);
+                });
+                it("should return the service instance", () => {
+                    expect(this.result).to.deep.eq("instance");
+                });
+            });
+
+            describe("when serviceType is a class from registry (know, instance defined, not buildable)", () => {
+                before(() => {
+                    this.symbol = class Test {
+                    };
+
+                    this.locals = new Map();
+                    this.getStub = Sinon.stub(GlobalProviders, "get").returns({
+                        instance: {instance: "instance"},
+                        useClass: "useClass",
+                        type: "provider"
+                    });
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns({
+                            buildable: false,
+                            injectable: true
+                        });
+
+                    this.invokeStub = Sinon.stub(InjectorService, "invoke").returns("instance");
+
+                    this.result = (InjectorService as any).mapServices({
+                        serviceType: this.symbol,
+                        locals: this.locals,
+                        requiredScope: true,
+                        target: class ServiceTest {
+                        }
+                    });
+                });
+
+                after(() => {
+                    this.getStub.restore();
+                    this.invokeStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                });
+
+                it("should call GlobalProviders.get", () => {
+                    this.getStub.should.have.been.calledWithExactly(this.symbol);
+                });
+
+                it("should call GlobalProviders.getRegistrySettings", () => {
+                    this.getRegistrySettingsStub.should.be.calledWithExactly("provider");
+                });
+                it("should build instance and return the service", () => {
+                    return this.invokeStub.should.not.have.been.called;
+                });
+                it("should return the service instance", () => {
+                    expect(this.result).to.deep.eq({instance: "instance"});
+                });
+            });
+
+            describe("when serviceType is a class from registry (know, instance defined, buildable, SINGLETON)", () => {
+                before(() => {
+                    this.symbol = class Test {
+                    };
+
+                    this.locals = new Map();
+                    this.getStub = Sinon.stub(GlobalProviders, "get").returns({
+                        instance: {instance: "instance"},
+                        useClass: "useClass",
+                        type: "provider",
+                        scope: ProviderScope.SINGLETON
+                    });
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns({
+                            buildable: true,
+                            injectable: true
+                        });
+
+                    this.invokeStub = Sinon.stub(InjectorService, "invoke").returns("instance");
+
+                    this.result = (InjectorService as any).mapServices({
+                        serviceType: this.symbol,
+                        locals: this.locals,
+                        requiredScope: true,
+                        target: class ServiceTest {
+                        }
+                    });
+                });
+
+                after(() => {
+                    this.getStub.restore();
+                    this.invokeStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                });
+
+                it("should call GlobalProviders.get", () => {
+                    this.getStub.should.have.been.calledWithExactly(this.symbol);
+                });
+
+                it("should call GlobalProviders.getRegistrySettings", () => {
+                    this.getRegistrySettingsStub.should.be.calledWithExactly("provider");
+                });
+                it("should not build instance", () => {
+                    return this.invokeStub.should.not.have.been.called;
+                });
+                it("should return the service instance", () => {
+                    expect(this.result).to.deep.eq({instance: "instance"});
+                });
+            });
+
+            describe("when serviceType is a class from registry (know, instance defined, buildable, REQUEST)", () => {
+                before(() => {
+                    this.symbol = class Test {
+                    };
+
+                    this.locals = new Map();
+                    this.getStub = Sinon.stub(GlobalProviders, "get").returns({
+                        instance: {instance: "instance"},
+                        useClass: "useClass",
+                        type: "provider",
+                        scope: ProviderScope.REQUEST
+                    });
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns({
+                            buildable: true,
+                            injectable: true
+                        });
+
+                    this.invokeStub = Sinon.stub(InjectorService, "invoke").returns("instance");
+
+                    this.result = (InjectorService as any).mapServices({
+                        serviceType: this.symbol,
+                        locals: this.locals,
+                        requiredScope: true,
+                        parentScope: true,
+                        target: class ServiceTest {
+                        }
+                    });
+                });
+
+                after(() => {
+                    this.getStub.restore();
+                    this.invokeStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                });
+
+                it("should call GlobalProviders.get", () => {
+                    this.getStub.should.have.been.calledWithExactly(this.symbol);
+                });
+
+                it("should call GlobalProviders.getRegistrySettings", () => {
+                    this.getRegistrySettingsStub.should.be.calledWithExactly("provider");
+                });
+                it("should build instance and return the service", () => {
+                    return this.invokeStub.should.have.been.calledWithExactly("useClass", this.locals, undefined, true);
+                });
+                it("should return the service instance", () => {
+                    expect(this.result).to.deep.eq("instance");
+                });
+            });
+
+            describe("when serviceType is a class from registry (know, instance defined, buildable, SCOPE ERROR)", () => {
+                before(() => {
+                    this.symbol = class Test {
+                    };
+
+                    this.locals = new Map();
+                    this.getStub = Sinon.stub(GlobalProviders, "get").returns({
+                        instance: {instance: "instance"},
+                        useClass: "useClass",
+                        type: "provider",
+                        scope: ProviderScope.REQUEST
+                    });
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns({
+                            buildable: true,
+                            injectable: true
+                        });
+
+                    this.invokeStub = Sinon.stub(InjectorService, "invoke").returns("instance");
+
+                    try {
+                        this.result = (InjectorService as any).mapServices({
+                            serviceType: this.symbol,
+                            locals: this.locals,
+                            requiredScope: true,
+                            parentScope: false,
+                            target: class ServiceTest {
+                            }
+                        });
+                    } catch (er) {
+                        this.error = er;
+                    }
+
+                });
+
+                after(() => {
+                    this.getStub.restore();
+                    this.invokeStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                });
+
+                it("should call GlobalProviders.get", () => {
+                    this.getStub.should.have.been.calledWithExactly(this.symbol);
+                });
+
+                it("should call GlobalProviders.getRegistrySettings", () => {
+                    this.getRegistrySettingsStub.should.be.calledWithExactly("provider");
+                });
+                it("should not build instance", () => {
+                    return this.invokeStub.should.not.have.been.called;
+                });
+                it("should throw an error", () => {
+                    expect(this.error.message).to.eq("Service of type useClass can not be injected as it is request scoped, while ServiceTest is singleton scoped");
+                });
+            });
+
+            describe("when serviceType is a class from registry (INJECTION ERROR)", () => {
+                before(() => {
+                    this.symbol = class Test {
+                    };
+
+                    this.locals = new Map();
+                    this.getStub = Sinon.stub(GlobalProviders, "get").returns({
+                        instance: {instance: "instance"},
+                        useClass: "useClass",
+                        type: "provider",
+                        scope: ProviderScope.REQUEST
+                    });
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns({
+                            buildable: true,
+                            injectable: true
+                        });
+
+                    this.invokeStub = Sinon.stub(InjectorService, "invoke").throws(new Error("Origin Error"));
+
+                    try {
+                        this.result = (InjectorService as any).mapServices({
+                            serviceType: this.symbol,
+                            locals: this.locals,
+                            requiredScope: true,
+                            parentScope: true,
+                            target: class ServiceTest {
+                            }
+                        });
+                    } catch (er) {
+                        this.error = er;
+                    }
+
+                });
+
+                after(() => {
+                    this.getStub.restore();
+                    this.invokeStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                });
+
+                it("should call GlobalProviders.get", () => {
+                    this.getStub.should.have.been.calledWithExactly(this.symbol);
+                });
+
+                it("should call GlobalProviders.getRegistrySettings", () => {
+                    this.getRegistrySettingsStub.should.be.calledWithExactly("provider");
+                });
+                it("should build instance and return the service", () => {
+                    return this.invokeStub.should.have.been.calledWithExactly("useClass", this.locals, undefined, true);
+                });
+                it("should throw an error", () => {
+                    expect(this.error.message).to.deep.eq("Service ServiceTest > Test injection failed.");
+                });
+
+                it("should throw an error with origin error", () => {
+                    expect(this.error.origin.message).to.deep.eq("Origin Error");
+                });
+            });
+
+            describe("when serviceType is a class from registry (NOT INJECTABLE)", () => {
+                before(() => {
+                    this.symbol = class Test {
+                    };
+
+                    this.locals = new Map();
+                    this.getStub = Sinon.stub(GlobalProviders, "get").returns({
+                        instance: {instance: "instance"},
+                        useClass: "useClass",
+                        type: "provider",
+                        scope: ProviderScope.REQUEST
+                    });
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns({
+                            buildable: true,
+                            injectable: false
+                        });
+
+                    this.invokeStub = Sinon.stub(InjectorService, "invoke");
+
+                    try {
+                        this.result = (InjectorService as any).mapServices({
+                            serviceType: this.symbol,
+                            locals: this.locals,
+                            requiredScope: true,
+                            parentScope: true,
+                            target: class ServiceTest {
+                            }
+                        });
+                    } catch (er) {
+                        this.error = er;
+                    }
+
+                });
+
+                after(() => {
+                    this.getStub.restore();
+                    this.invokeStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                });
+
+                it("should call GlobalProviders.get", () => {
+                    this.getStub.should.have.been.calledWithExactly(this.symbol);
+                });
+
+                it("should call GlobalProviders.getRegistrySettings", () => {
+                    this.getRegistrySettingsStub.should.be.calledWithExactly("provider");
+                });
+                it("should not build service", () => {
+                    return this.invokeStub.should.not.have.been.called;
+                });
+                it("should throw an error", () => {
+                    expect(this.error.message).to.deep.eq("Service ServiceTest > Test not injectable.");
+                });
+            });
+
+        });
     });
 
     describe("instance members", () => {
 
         describe("get()", () => {
-
             it("should get a service", inject([InjectorService], (injectorService: InjectorService) => {
                 expect(injectorService.get(InjectorService)).to.be.an.instanceof(InjectorService);
             }));
@@ -90,7 +545,6 @@ describe("InjectorService", () => {
             it("should has the service", inject([InjectorService], (injectorService: InjectorService) => {
                 expect(injectorService.has(InjectorService)).to.be.true;
             }));
-
         });
 
         describe("construct()", () => {
@@ -107,6 +561,337 @@ describe("InjectorService", () => {
         });
 
         describe("invoke()", () => {
+            class Test {
+                args: any[];
+
+                constructor(...args: any[]) {
+                    this.args = args;
+                }
+            }
+
+            class TestDep {
+
+            }
+
+            describe("when designParamsTypes is not given", () => {
+                before(inject([InjectorService], (injectorService: InjectorService) => {
+
+                    this.registrySettings = {
+                        onInvoke: Sinon.stub()
+                    };
+
+                    this.designParamTypes = [TestDep];
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns(this.registrySettings);
+
+                    this.getParamTypesStub = Sinon
+                        .stub(Metadata, "getParamTypes")
+                        .returns(this.designParamTypes);
+
+                    this.getStub = Sinon
+                        .stub(GlobalProviders, "get")
+                        .returns({provide: "provide"});
+
+                    this.mapServicesStub = Sinon
+                        .stub(InjectorService as any, "mapServices")
+                        .returns(this.dep = new TestDep);
+
+                    Store.from(Test).set("scope", "request");
+
+                    this.locals = new Map();
+                    this.result = injectorService.invoke(
+                        Test,
+                        this.locals,
+                        undefined,
+                        false
+                    );
+                }));
+
+                after(() => {
+                    this.mapServicesStub.restore();
+                    this.getStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                    this.getParamTypesStub.restore();
+                });
+
+                it("should call GlobalProviders.getRegistrySettings method", () => {
+                    this.getRegistrySettingsStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("should call GlobalProviders.get method", () => {
+                    this.getStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("should call Metadata.getParamTypes method", () => {
+                    this.getParamTypesStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("should call settings.onInvoke method", () => {
+                    this.registrySettings.onInvoke.should.have.been.calledWithExactly(
+                        {provide: "provide"},
+                        this.locals,
+                        this.designParamTypes
+                    );
+                });
+
+                it("should call injectorService.mapServices method", () => {
+                    this.mapServicesStub.should.have.been.calledWithExactly({
+                        target: Test,
+                        serviceType: TestDep,
+                        locals: this.locals,
+                        requiredScope: false,
+                        parentScope: "request"
+                    });
+                });
+
+                it("should return a new instance of the given service", () => {
+                    expect(this.result).to.instanceOf(Test);
+                });
+
+                it("should injected services into the given service constructor", () => {
+                    expect(this.result.args).to.deep.eq([
+                        this.dep
+                    ]);
+                });
+            });
+            describe("when designParamsTypes is given", () => {
+                before(inject([InjectorService], (injectorService: InjectorService) => {
+
+                    this.registrySettings = {
+                        onInvoke: Sinon.stub()
+                    };
+
+                    this.designParamTypes = [TestDep];
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns(this.registrySettings);
+
+                    this.getParamTypesStub = Sinon
+                        .stub(Metadata, "getParamTypes");
+
+                    this.getStub = Sinon
+                        .stub(GlobalProviders, "get")
+                        .returns({provide: "provide"});
+
+                    this.mapServicesStub = Sinon
+                        .stub(InjectorService as any, "mapServices")
+                        .returns(this.dep = new TestDep);
+
+                    Store.from(Test).set("scope", "request");
+
+                    this.locals = new Map();
+                    this.result = injectorService.invoke(
+                        Test,
+                        this.locals,
+                        this.designParamTypes,
+                        false
+                    );
+                }));
+
+                after(() => {
+                    this.mapServicesStub.restore();
+                    this.getStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                    this.getParamTypesStub.restore();
+                });
+
+                it("should call GlobalProviders.getRegistrySettings method", () => {
+                    this.getRegistrySettingsStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("should call GlobalProviders.get method", () => {
+                    this.getStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("shouldn't call Metadata.getParamTypes method", () => {
+                    return this.getParamTypesStub.should.not.have.been.called;
+                });
+
+                it("should call settings.onInvoke method", () => {
+                    this.registrySettings.onInvoke.should.have.been.calledWithExactly(
+                        {provide: "provide"},
+                        this.locals,
+                        this.designParamTypes
+                    );
+                });
+
+                it("should call injectorService.mapServices method", () => {
+                    this.mapServicesStub.should.have.been.calledWithExactly({
+                        target: Test,
+                        serviceType: TestDep,
+                        locals: this.locals,
+                        requiredScope: false,
+                        parentScope: "request"
+                    });
+                });
+
+                it("should return a new instance of the given service", () => {
+                    expect(this.result).to.instanceOf(Test);
+                });
+
+                it("should injected services into the given service constructor", () => {
+                    expect(this.result.args).to.deep.eq([
+                        this.dep
+                    ]);
+                });
+            });
+            describe("when onInvoke is empty", () => {
+                before(inject([InjectorService], (injectorService: InjectorService) => {
+
+                    this.registrySettings = {};
+                    this.designParamTypes = [TestDep];
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns(this.registrySettings);
+
+                    this.getParamTypesStub = Sinon
+                        .stub(Metadata, "getParamTypes")
+                        .returns(this.designParamTypes);
+
+                    this.getStub = Sinon
+                        .stub(GlobalProviders, "get")
+                        .returns({provide: "provide"});
+
+                    this.mapServicesStub = Sinon
+                        .stub(InjectorService as any, "mapServices")
+                        .returns(this.dep = new TestDep);
+
+                    Store.from(Test).set("scope", "request");
+
+                    this.locals = new Map();
+                    this.result = injectorService.invoke(
+                        Test,
+                        this.locals,
+                        undefined,
+                        false
+                    );
+                }));
+
+                after(() => {
+                    this.mapServicesStub.restore();
+                    this.getStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                    this.getParamTypesStub.restore();
+                });
+
+                it("should call GlobalProviders.getRegistrySettings method", () => {
+                    this.getRegistrySettingsStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("should call GlobalProviders.get method", () => {
+                    this.getStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("should call Metadata.getParamTypes method", () => {
+                    this.getParamTypesStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("should call injectorService.mapServices method", () => {
+                    this.mapServicesStub.should.have.been.calledWithExactly({
+                        target: Test,
+                        serviceType: TestDep,
+                        locals: this.locals,
+                        requiredScope: false,
+                        parentScope: "request"
+                    });
+                });
+
+                it("should return a new instance of the given service", () => {
+                    expect(this.result).to.instanceOf(Test);
+                });
+
+                it("should injected services into the given service constructor", () => {
+                    expect(this.result.args).to.deep.eq([
+                        this.dep
+                    ]);
+                });
+            });
+            describe("when provider didn\'t exists", () => {
+                before(inject([InjectorService], (injectorService: InjectorService) => {
+
+                    this.registrySettings = {
+                        onInvoke: Sinon.stub()
+                    };
+                    this.designParamTypes = [TestDep];
+
+                    this.getRegistrySettingsStub = Sinon
+                        .stub(GlobalProviders, "getRegistrySettings")
+                        .returns(this.registrySettings);
+
+                    this.getParamTypesStub = Sinon
+                        .stub(Metadata, "getParamTypes")
+                        .returns(this.designParamTypes);
+
+                    this.getStub = Sinon
+                        .stub(GlobalProviders, "get")
+                        .returns(undefined);
+
+                    this.mapServicesStub = Sinon
+                        .stub(InjectorService as any, "mapServices")
+                        .returns(this.dep = new TestDep);
+
+                    Store.from(Test).set("scope", "request");
+
+                    this.locals = new Map();
+                    this.result = injectorService.invoke(
+                        Test,
+                        this.locals,
+                        undefined,
+                        false
+                    );
+                }));
+
+                after(() => {
+                    this.mapServicesStub.restore();
+                    this.getStub.restore();
+                    this.getRegistrySettingsStub.restore();
+                    this.getParamTypesStub.restore();
+                });
+
+                it("should call GlobalProviders.getRegistrySettings method", () => {
+                    this.getRegistrySettingsStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("should call GlobalProviders.get method", () => {
+                    this.getStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("should call Metadata.getParamTypes method", () => {
+                    this.getParamTypesStub.should.have.been.calledWithExactly(Test);
+                });
+
+                it("shouldn't call settings.onInvoke method", () => {
+                    return this.registrySettings.onInvoke.should.not.have.been.called;
+                });
+
+                it("should call injectorService.mapServices method", () => {
+                    this.mapServicesStub.should.have.been.calledWithExactly({
+                        target: Test,
+                        serviceType: TestDep,
+                        locals: this.locals,
+                        requiredScope: false,
+                        parentScope: "request"
+                    });
+                });
+
+                it("should return a new instance of the given service", () => {
+                    expect(this.result).to.instanceOf(Test);
+                });
+
+                it("should injected services into the given service constructor", () => {
+                    expect(this.result.args).to.deep.eq([
+                        this.dep
+                    ]);
+                });
+            });
+        });
+
+
+        /*describe("invoke()", () => {
             it("should invoke a function constructor", inject([InjectorService], (injectorService: InjectorService) => {
                 const fnInvokable = function (injectorService: InjectorService) {
                     expect(injectorService).to.be.an.instanceof(InjectorService);
@@ -199,7 +984,7 @@ describe("InjectorService", () => {
                     });
                 });
             });
-        });
+        });*/
 
         describe("invokeMethod()", () => {
 

--- a/test/units/mvc/class/ControllerProvider.spec.ts
+++ b/test/units/mvc/class/ControllerProvider.spec.ts
@@ -13,7 +13,6 @@ describe("ControllerProvider", () => {
     before(() => {
         this.ControllerProvider = new ControllerProvider(Test);
         this.ControllerProvider.path = "/";
-        this.ControllerProvider.pushRouterPath("/");
         this.ControllerProvider.dependencies = [Test2];
         this.ControllerProvider.scope = "request";
         this.ControllerProvider.routerOptions = {};
@@ -30,10 +29,6 @@ describe("ControllerProvider", () => {
 
     it("should get path", () =>
         expect(this.ControllerProvider.path).to.equal("/")
-    );
-
-    it("should get routerPaths", () =>
-        expect(this.ControllerProvider.routerPaths).to.be.an("array").and.have.length(1)
     );
 
     it("should get endpoints", () =>

--- a/test/units/mvc/class/EndpointBuilder.spec.ts
+++ b/test/units/mvc/class/EndpointBuilder.spec.ts
@@ -1,27 +1,13 @@
 import * as Express from "express";
-import * as Proxyquire from "proxyquire";
 import {globalServerSettings} from "../../../../src/common/config";
+import {EndpointBuilder} from "../../../../src/common/mvc/class/EndpointBuilder";
 
 import {EndpointMetadata} from "../../../../src/common/mvc/class/EndpointMetadata";
+import {HandlerBuilder} from "../../../../src/common/mvc/class/HandlerBuilder";
 import {inject} from "../../../../src/testing/inject";
 import {FakeRequest} from "../../../helper/FakeRequest";
 import {FakeResponse} from "../../../helper/FakeResponse";
 import {expect, Sinon} from "../../../tools";
-
-
-const HandlerBuilder = {
-    from: Sinon.stub().returns({
-        build: Sinon.stub().returns(() => {
-
-        })
-    })
-};
-
-const {EndpointBuilder} = Proxyquire("../../../../src/common/mvc/class/EndpointBuilder", {
-    "./HandlerBuilder": {
-        HandlerBuilder
-    }
-});
 
 class Test {
     method() {
@@ -33,6 +19,13 @@ describe("EndpointBuilder", () => {
 
     before(inject([], () => {
         this.router = Express.Router();
+        this.builder = {
+            build: Sinon.stub().returns(() => {
+
+            })
+        };
+        this.fromStub = Sinon.stub(HandlerBuilder, "from").returns(this.builder);
+
         Sinon.stub(this.router, "use");
         Sinon.stub(this.router, "get");
 
@@ -43,6 +36,7 @@ describe("EndpointBuilder", () => {
     after(() => {
         this.router.get.restore();
         this.router.use.restore();
+        this.fromStub.restore();
         delete this.router;
         delete this.endpointMetadata;
         delete this.endpointBuilder;
@@ -64,7 +58,7 @@ describe("EndpointBuilder", () => {
                 });
 
                 it("should call HandlerBuilder", () => {
-                    expect(HandlerBuilder.from.called).to.eq(true);
+                    return this.fromStub.should.have.been.called;
                 });
 
                 it("should call use method", () =>
@@ -89,7 +83,7 @@ describe("EndpointBuilder", () => {
                 });
 
                 it("should call HandlerBuilder", () => {
-                    expect(HandlerBuilder.from.called).to.eq(true);
+                    return this.fromStub.should.have.been.called;
                 });
 
                 it("should call use method", () =>
@@ -116,7 +110,7 @@ describe("EndpointBuilder", () => {
             });
 
             it("should call HandlerBuilder", () => {
-                expect(HandlerBuilder.from.called).to.eq(true);
+                return this.fromStub.should.have.been.called;
             });
 
             it("should call get method", () =>

--- a/test/units/mvc/class/HandlerBuilder.spec.ts
+++ b/test/units/mvc/class/HandlerBuilder.spec.ts
@@ -1,3 +1,4 @@
+import {ProviderType} from "@tsed/common";
 import {BadRequest} from "ts-httpexceptions";
 import "../../../../src/ajv";
 import {globalServerSettings} from "../../../../src/common/config";
@@ -7,8 +8,6 @@ import {FilterBuilder} from "../../../../src/common/filters/class/FilterBuilder"
 import {EndpointMetadata} from "../../../../src/common/mvc/class/EndpointMetadata";
 import {HandlerBuilder} from "../../../../src/common/mvc/class/HandlerBuilder";
 import {CastError} from "../../../../src/common/mvc/errors/CastError";
-import {ControllerRegistry} from "../../../../src/common/mvc/registries/ControllerRegistry";
-import {RouterController} from "../../../../src/common/mvc/services/RouterController";
 import {FakeRequest} from "../../../helper/FakeRequest";
 import {FakeResponse} from "../../../helper/FakeResponse";
 import {$logStub, assert, expect, restore, Sinon} from "../../../tools";
@@ -457,42 +456,48 @@ describe("HandlerBuilder", () => {
                 this.handlerBuilder.getHandler().should.eq("target");
             });
         });
-        describe("middleware", () => {
+        describe("component (middleware)", () => {
             before(() => {
                 this.handlerMetadata = {
-                    type: "middleware",
+                    type: ProviderType.MIDDLEWARE,
                     target: "target"
                 };
                 this.handlerBuilder = new HandlerBuilder(this.handlerMetadata);
-                this.middlewareHandlerStub = Sinon.stub(this.handlerBuilder, "middlewareHandler");
-                this.middlewareHandlerStub.returns("handlerMiddleware");
+                this.buildHandlerStub = Sinon.stub(this.handlerBuilder, "buildHandler");
+                this.buildHandlerStub.returns("handlerMiddleware");
                 this.result = this.handlerBuilder.getHandler();
             });
 
             it("should have called the middlewareHandler method", () => {
-                return this.middlewareHandlerStub.should.have.been.called;
+                return this.buildHandlerStub.should.have.been.called;
             });
 
             it("should return the function handler", () => {
                 this.result.should.eq("handlerMiddleware");
             });
         });
-        describe("controller", () => {
+        describe("component (controller)", () => {
             before(() => {
                 this.handlerMetadata = {
-                    type: "controller",
+                    type: ProviderType.CONTROLLER,
                     target: "target"
                 };
                 this.handlerBuilder = new HandlerBuilder(this.handlerMetadata);
-                Sinon.stub(this.handlerBuilder, "endpointHandler").returns("endpointHandler");
+                this.buildHandlerStub = Sinon.stub(this.handlerBuilder, "buildHandler");
+                this.buildHandlerStub.returns("endpointHandler");
+                this.result = this.handlerBuilder.getHandler();
             });
+            it("should have called the middlewareHandler method", () => {
+                return this.buildHandlerStub.should.have.been.called;
+            });
+
             it("should return the function handler", () => {
-                this.handlerBuilder.getHandler().should.eq("endpointHandler");
+                this.result.should.eq("endpointHandler");
             });
         });
     });
-    describe("endpointHandler()", () => {
-        describe("when the controller is known", () => {
+    describe("buildHandler()", () => {
+        describe("when component is known", () => {
             before(() => {
                 this.instance = {
                     method: () => {
@@ -501,7 +506,7 @@ describe("HandlerBuilder", () => {
                 this.invokeStub = Sinon.stub(InjectorService, "invoke");
                 this.invokeStub.returns(this.instance);
 
-                this.controllerGetStub = Sinon.stub(ControllerRegistry, "get");
+                this.controllerGetStub = Sinon.stub(ProviderRegistry, "get");
                 this.controllerGetStub.returns({
                     useClass: "providerClass"
                 });
@@ -512,7 +517,7 @@ describe("HandlerBuilder", () => {
                 this.handlerBuilder = new HandlerBuilder(this.handlerMetadata);
 
                 this.locals = new Map<string | Function, any>();
-                this.result = this.handlerBuilder.endpointHandler(this.locals);
+                this.result = this.handlerBuilder.buildHandler(this.locals);
             });
 
             after(() => {
@@ -520,7 +525,7 @@ describe("HandlerBuilder", () => {
                 this.invokeStub.restore();
             });
 
-            it("should have called the ControllerRegistry.get method", () => {
+            it("should have called the ProviderRegistry.get method", () => {
                 this.controllerGetStub.should.have.been.calledWithExactly("target");
             });
             it("should have called the invoke method", () => {
@@ -529,11 +534,8 @@ describe("HandlerBuilder", () => {
             it("should return the handler", () => {
                 this.result.should.have.been.a("function");
             });
-            it("should have a RouterController stored in the locals", () => {
-                expect(this.locals.has(RouterController)).to.be.true;
-            });
         });
-        describe("when the controller is known and instance is already built", () => {
+        describe("when component is known and instance is already built", () => {
             before(() => {
                 this.instance = {
                     method: () => {
@@ -541,7 +543,7 @@ describe("HandlerBuilder", () => {
                 };
                 this.invokeStub = Sinon.stub(InjectorService, "invoke");
 
-                this.controllerGetStub = Sinon.stub(ControllerRegistry, "get");
+                this.controllerGetStub = Sinon.stub(ProviderRegistry, "get");
                 this.controllerGetStub.returns({
                     useClass: "providerClass",
                     instance: this.instance,
@@ -552,7 +554,7 @@ describe("HandlerBuilder", () => {
                     methodClassName: "method"
                 };
                 this.handlerBuilder = new HandlerBuilder(this.handlerMetadata);
-                this.result = this.handlerBuilder.endpointHandler();
+                this.result = this.handlerBuilder.buildHandler();
             });
 
             after(() => {
@@ -560,7 +562,7 @@ describe("HandlerBuilder", () => {
                 this.invokeStub.restore();
             });
 
-            it("should have called the ControllerRegistry.get method", () => {
+            it("should have called the ProviderRegistry.get method", () => {
                 this.controllerGetStub.should.have.been.calledWithExactly("target");
             });
             it("should not have called the invoke method", () => {
@@ -570,11 +572,11 @@ describe("HandlerBuilder", () => {
                 this.result.should.have.been.a("function");
             });
         });
-        describe("when the controller is unknown", () => {
+        describe("when component is unknown", () => {
             before(() => {
                 this.invokeStub = Sinon.stub(InjectorService, "invoke");
 
-                this.controllerGetStub = Sinon.stub(ControllerRegistry, "get");
+                this.controllerGetStub = Sinon.stub(ProviderRegistry, "get");
                 this.controllerGetStub.returns(undefined);
                 this.handlerMetadata = {
                     target: "target",
@@ -589,88 +591,11 @@ describe("HandlerBuilder", () => {
             });
 
             it("should throw an exception", () => {
-                assert.throws(() => this.handlerBuilder.endpointHandler(), "Controller component not found in the ControllerRegistry");
+                assert.throws(() => this.handlerBuilder.buildHandler(), "target component not found in the ProviderRegistry");
             });
         });
     });
-    describe("middlewareHandler()", () => {
-        describe("when middleware is known", () => {
-            before(() => {
-                this.middlewareGetStub = Sinon.stub(ProviderRegistry, "get");
-                this.middlewareGetStub.returns({
-                    instance: {
-                        use: () => {
-                        }
-                    },
-                    scope: "singleton"
-                });
-                this.handlerMetadata = {
-                    target: "target"
-                };
-                this.handlerBuilder = new HandlerBuilder(this.handlerMetadata);
-                this.result = this.handlerBuilder.middlewareHandler();
-            });
-            after(() => {
-                this.middlewareGetStub.restore();
-            });
-            it("should have called the ProviderRegistry.get method", () => {
-                this.middlewareGetStub.should.have.been.calledWithExactly("target");
-            });
-            it("should return the handler", () => {
-                this.result.should.have.been.a("function");
-            });
-        });
 
-        describe("when middleware is unknown", () => {
-            before(() => {
-                this.middlewareGetStub = Sinon.stub(ProviderRegistry, "get");
-                this.middlewareGetStub.returns(undefined);
-                this.handlerMetadata = {
-                    target: "target"
-                };
-                this.handlerBuilder = new HandlerBuilder(this.handlerMetadata);
-            });
-            after(() => {
-                this.middlewareGetStub.restore();
-            });
-            it("should throw an error", () => {
-                assert.throws(() => {
-                    this.handlerBuilder.middlewareHandler();
-                }, "target middleware component not found in the MiddlewareRegistry");
-            });
-        });
-
-        describe("with a scope options", () => {
-            before(() => {
-                this.invokeStub = Sinon.stub(InjectorService, "invoke").returns({
-                    use: () => {
-                    }
-                });
-
-                this.middlewareGetStub = Sinon.stub(ProviderRegistry, "get");
-                this.middlewareGetStub.returns({
-                    useClass: "class",
-                    scope: "request"
-                });
-
-                this.handlerMetadata = {
-                    target: "target"
-                };
-                this.handlerBuilder = new HandlerBuilder(this.handlerMetadata);
-                this.result = this.handlerBuilder.middlewareHandler();
-            });
-            after(() => {
-                this.middlewareGetStub.restore();
-                this.invokeStub.restore();
-            });
-            it("should return a new instance of middleware", () => {
-                this.invokeStub.should.have.been.calledWithExactly("class", undefined, undefined, true);
-            });
-            it("should return an handler", () => {
-                this.result.should.have.been.a("function");
-            });
-        });
-    });
     describe("runFilters()", () => {
         describe("when success", () => {
             before(() => {

--- a/test/units/mvc/class/HandlerMetadata.spec.ts
+++ b/test/units/mvc/class/HandlerMetadata.spec.ts
@@ -1,5 +1,5 @@
 import {Store} from "@tsed/core";
-import {ControllerRegistry, ParamRegistry, ProviderRegistry, ProviderType} from "../../../../src/common";
+import {ParamRegistry, ProviderRegistry, ProviderType} from "../../../../src/common";
 import {HandlerMetadata} from "../../../../src/common/mvc/class/HandlerMetadata";
 import {MiddlewareType} from "../../../../src/common/mvc/interfaces";
 import {getClass} from "../../../../src/core/utils";
@@ -27,8 +27,6 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub = Sinon.stub(ParamRegistry, "isInjectable").returns(false);
             this.hasNextFunctionStub = Sinon.stub(ParamRegistry, "hasNextFunction").returns(true);
             this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(false);
-            this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
-
             this.handlerMetadata = new HandlerMetadata((req: any, res: any, next: any) => {
             });
         });
@@ -37,7 +35,6 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub.restore();
             this.hasNextFunctionStub.restore();
             this.providerHasStub.restore();
-            this.controllerHasStub.restore();
         });
 
         it("shouldn't be injectable", () => {
@@ -66,7 +63,6 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub = Sinon.stub(ParamRegistry, "isInjectable").returns(false);
             this.hasNextFunctionStub = Sinon.stub(ParamRegistry, "hasNextFunction").returns(true);
             this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(false);
-            this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
 
             this.handlerMetadata = new HandlerMetadata((err: any, req: any, res: any, next: any) => {
             });
@@ -76,7 +72,6 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub.restore();
             this.hasNextFunctionStub.restore();
             this.providerHasStub.restore();
-            this.controllerHasStub.restore();
         });
 
         it("shouldn't be injectable", () => {
@@ -105,7 +100,6 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub = Sinon.stub(ParamRegistry, "isInjectable").returns(false);
             this.hasNextFunctionStub = Sinon.stub(ParamRegistry, "hasNextFunction").returns(true);
             this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(false);
-            this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
 
             this.handlerMetadata = new HandlerMetadata((req: any, res: any) => {
             });
@@ -115,14 +109,13 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub.restore();
             this.hasNextFunctionStub.restore();
             this.providerHasStub.restore();
-            this.controllerHasStub.restore();
         });
 
         it("shouldn't be injectable", () => {
             expect(this.handlerMetadata.injectable).to.eq(false);
         });
 
-        it("should return controller type", () => {
+        it("should return function type", () => {
             expect(this.handlerMetadata.type).to.eq("function");
         });
 
@@ -143,8 +136,12 @@ describe("HandlerMetadata", () => {
         before(() => {
             this.isInjectableStub = Sinon.stub(ParamRegistry, "isInjectable").returns(false);
             this.hasNextFunctionStub = Sinon.stub(ParamRegistry, "hasNextFunction").returns(true);
-            this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(false);
-            this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(true);
+            this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(true);
+            this.providerGetStub = Sinon.stub(ProviderRegistry, "get").returns({
+                provide: getClass(Test),
+                useClass: getClass(Test),
+                type: ProviderType.CONTROLLER
+            });
 
             this.handlerMetadata = new HandlerMetadata(Test, "test");
         });
@@ -153,7 +150,7 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub.restore();
             this.hasNextFunctionStub.restore();
             this.providerHasStub.restore();
-            this.controllerHasStub.restore();
+            this.providerGetStub.restore();
         });
 
         it("shouldn't be injectable", () => {
@@ -181,8 +178,12 @@ describe("HandlerMetadata", () => {
         before(() => {
             this.isInjectableStub = Sinon.stub(ParamRegistry, "isInjectable").returns(true);
             this.hasNextFunctionStub = Sinon.stub(ParamRegistry, "hasNextFunction").returns(true);
-            this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(false);
-            this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(true);
+            this.providerHasStub = Sinon.stub(ProviderRegistry, "has").returns(true);
+            this.providerGetStub = Sinon.stub(ProviderRegistry, "get").returns({
+                provide: getClass(Test),
+                useClass: getClass(Test),
+                type: ProviderType.CONTROLLER
+            });
 
             this.handlerMetadata = new HandlerMetadata(Test, "test");
         });
@@ -191,7 +192,7 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub.restore();
             this.hasNextFunctionStub.restore();
             this.providerHasStub.restore();
-            this.controllerHasStub.restore();
+            this.providerGetStub.restore();
         });
 
         it("should be injectable", () => {
@@ -227,7 +228,6 @@ describe("HandlerMetadata", () => {
             });
 
             Store.from(Test).set("middlewareType", MiddlewareType.MIDDLEWARE);
-            this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
 
             this.handlerMetadata = new HandlerMetadata(Test);
         });
@@ -236,7 +236,6 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub.restore();
             this.hasNextFunctionStub.restore();
             this.providerHasStub.restore();
-            this.controllerHasStub.restore();
             this.providerGetStub.restore();
         });
 
@@ -244,7 +243,7 @@ describe("HandlerMetadata", () => {
             expect(this.handlerMetadata.injectable).to.eq(true);
         });
 
-        it("should return controller type", () => {
+        it("should return middleware type", () => {
             expect(this.handlerMetadata.type).to.eq("middleware");
         });
 
@@ -282,8 +281,6 @@ describe("HandlerMetadata", () => {
 
             Store.from(Test).set("middlewareType", MiddlewareType.MIDDLEWARE);
 
-            this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
-
             this.handlerMetadata = new HandlerMetadata(Test);
         });
 
@@ -291,7 +288,6 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub.restore();
             this.hasNextFunctionStub.restore();
             this.providerHasStub.restore();
-            this.controllerHasStub.restore();
             this.providerGetStub.restore();
         });
 
@@ -299,7 +295,7 @@ describe("HandlerMetadata", () => {
             expect(this.handlerMetadata.injectable).to.eq(false);
         });
 
-        it("should return controller type", () => {
+        it("should return middleware type", () => {
             expect(this.handlerMetadata.type).to.eq("middleware");
         });
 
@@ -337,8 +333,6 @@ describe("HandlerMetadata", () => {
 
             Store.from(Test).set("middlewareType", MiddlewareType.ERROR);
 
-            this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
-
             this.handlerMetadata = new HandlerMetadata(Test);
         });
 
@@ -346,7 +340,6 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub.restore();
             this.hasNextFunctionStub.restore();
             this.providerHasStub.restore();
-            this.controllerHasStub.restore();
             this.providerGetStub.restore();
         });
 
@@ -354,7 +347,7 @@ describe("HandlerMetadata", () => {
             expect(this.handlerMetadata.injectable).to.eq(true);
         });
 
-        it("should return controller type", () => {
+        it("should return middleware type", () => {
             expect(this.handlerMetadata.type).to.eq("middleware");
         });
 
@@ -390,9 +383,6 @@ describe("HandlerMetadata", () => {
             });
 
             Store.from(Test).set("middlewareType", MiddlewareType.ERROR);
-
-            this.controllerHasStub = Sinon.stub(ControllerRegistry, "has").returns(false);
-
             this.handlerMetadata = new HandlerMetadata(Test2);
         });
 
@@ -400,7 +390,6 @@ describe("HandlerMetadata", () => {
             this.isInjectableStub.restore();
             this.hasNextFunctionStub.restore();
             this.providerHasStub.restore();
-            this.controllerHasStub.restore();
             this.providerGetStub.restore();
         });
 
@@ -408,7 +397,7 @@ describe("HandlerMetadata", () => {
             expect(this.handlerMetadata.injectable).to.eq(false);
         });
 
-        it("should return controller type", () => {
+        it("should return middleware type", () => {
             expect(this.handlerMetadata.type).to.eq("middleware");
         });
 

--- a/test/units/mvc/registries/ControllerRegistry.spec.ts
+++ b/test/units/mvc/registries/ControllerRegistry.spec.ts
@@ -1,0 +1,28 @@
+import {ControllerProvider, ExpressRouter, GlobalProviders, ProviderType, RouterController} from "@tsed/common";
+import {expect} from "../../../tools";
+
+describe("ControllerRegistry", () => {
+    class Test {
+    }
+
+    before(() => {
+        const settings = GlobalProviders.getRegistrySettings(ProviderType.CONTROLLER);
+
+        this.locals = new Map();
+        this.provider = new ControllerProvider(Test);
+        this.provider.router = "router";
+        settings.onInvoke!(this.provider, this.locals, []);
+    });
+
+    it("should store RouterController (deprecated)", () => {
+        expect(this.locals.has(RouterController)).to.eq(true);
+    });
+
+    it("should store ExpressRouter", () => {
+        expect(this.locals.has(ExpressRouter)).to.eq(true);
+    });
+
+    it("should return ExpressRouter", () => {
+        expect(this.locals.get(ExpressRouter)).to.eq("router");
+    });
+});

--- a/test/units/mvc/services/ControllerService.spec.ts
+++ b/test/units/mvc/services/ControllerService.spec.ts
@@ -1,9 +1,6 @@
-import {ExpressRouter} from "@tsed/common";
-import {InjectorService} from "../../../../src/common/di/services/InjectorService";
+import {inject} from "@tsed/testing";
 import {ControllerProvider} from "../../../../src/common/mvc/class/ControllerProvider";
-import {ControllerRegistry} from "../../../../src/common/mvc/registries/ControllerRegistry";
 import {ControllerService} from "../../../../src/common/mvc/services/ControllerService";
-import {inject} from "../../../../src/testing/inject";
 import {expect, Sinon} from "../../../tools";
 
 
@@ -45,99 +42,6 @@ describe("ControllerService", () => {
         });
     });
 
-    describe("buildControllers()", () => {
-        before(() => {
-            this.getStub = Sinon.stub(ControllerRegistry, "get");
-            this.hasStub = Sinon.stub(ControllerRegistry, "has");
-            this.forEachStub = Sinon.stub(ControllerRegistry, "forEach");
-        });
-
-        after(() => {
-            this.getStub.restore();
-            this.hasStub.restore();
-            this.forEachStub.restore();
-        });
-        describe("when the controller is not scoped", () => {
-            before(() => {
-                this.expressApplicationStub = {use: Sinon.stub()};
-                this.controllerProvider = new ControllerProvider(Test);
-                this.controllerProvider.pushRouterPath("/rest");
-                this.controllerProvider.path = "test";
-                this.controllerProvider.scope = false;
-
-                this.controllerService = new ControllerService(InjectorService as any, this.expressApplicationStub, {routers: {}} as any);
-
-                this.invokeStub = Sinon.stub(this.controllerService, "invoke");
-                this.invokeStub.returns({instance: "instance"});
-                this.controllerService.buildControllers();
-
-                this.forEachStub.callArgWith(0, this.controllerProvider);
-            });
-
-            after(() => {
-                this.invokeStub.restore();
-            });
-
-            it("should called forEach()", () => {
-                ControllerRegistry.forEach.should.have.been.called;
-            });
-
-            it("should called use()", () => {
-                this.expressApplicationStub.use.should.have.been.called;
-            });
-
-            it("should append routerController to expressApplication", () => {
-                this.expressApplicationStub.use.calledWithExactly("/rest/test", Sinon.match.func);
-            });
-
-            it("should built the controller", () => {
-                return this.invokeStub.should.be.calledOnce.and.calledWithExactly(this.controllerProvider.useClass);
-            });
-
-            it("should store the instance", () => {
-                this.controllerProvider.instance.should.deep.eq({instance: "instance"});
-            });
-        });
-
-        describe("when the controller is scoped", () => {
-            before(() => {
-                this.expressApplicationStub = {use: Sinon.stub()};
-                this.controllerProvider = new ControllerProvider(Test);
-                this.controllerProvider.pushRouterPath("/rest");
-                this.controllerProvider.path = "test";
-                this.controllerProvider.scope = "request";
-
-                this.controllerService = new ControllerService(InjectorService as any, this.expressApplicationStub, {routers: {}} as any);
-
-                this.invokeStub = Sinon.stub(this.controllerService, "invoke");
-                this.controllerService.buildControllers();
-
-                this.forEachStub.callArgWith(0, this.controllerProvider);
-            });
-
-            after(() => {
-                this.invokeStub.restore();
-            });
-
-            it("should called forEach()", () => {
-                ControllerRegistry.forEach.should.have.been.called;
-            });
-
-            it("should called use()", () => {
-                this.expressApplicationStub.use.should.have.been.called;
-            });
-
-            it("should append routerController to expressApplication", () => {
-                this.expressApplicationStub.use.calledWithExactly("/rest/test", Sinon.match.func);
-            });
-
-            it("should not built the controller", () => {
-                return this.invokeStub.should.not.be.called;
-            });
-        });
-
-    });
-
     describe("invoke()", () => {
         describe("when the controller hasn't a configured provider", () => {
 
@@ -145,54 +49,18 @@ describe("ControllerService", () => {
             }
 
             before(inject([ControllerService], (controllerService: ControllerService) => {
-
-                this.hasStub = Sinon.stub((controllerService as any).registry, "has").returns(false);
                 this.invokeStub = Sinon.stub((controllerService as any).injectorService, "invoke");
 
                 controllerService.invoke(Test2);
-                this.map = this.invokeStub.getCall(0).args[1];
             }));
 
             after(() => {
-                this.hasStub.restore();
                 this.invokeStub.restore();
             });
 
             it("should call the fake service", () =>
                 this.invokeStub.should.have.been.calledWithExactly(Test2, Sinon.match.any, undefined)
             );
-            it("should store route in the locals map", () => {
-                expect(this.map.get(ExpressRouter)).to.be.a("function");
-            });
-        });
-
-        describe("when the controller has a configured provider", () => {
-
-            class Test2 {
-            }
-
-            before(inject([ControllerService], (controllerService: ControllerService) => {
-
-                this.hasStub = Sinon.stub((controllerService as any).registry, "has").returns(true);
-                this.getStub = Sinon.stub((controllerService as any).registry, "get").returns({router: "router"});
-                this.invokeStub = Sinon.stub((controllerService as any).injectorService, "invoke");
-
-                controllerService.invoke(Test2);
-                this.map = this.invokeStub.getCall(0).args[1];
-            }));
-
-            after(() => {
-                this.hasStub.restore();
-                this.getStub.restore();
-                this.invokeStub.restore();
-            });
-
-            it("should call the fake service", () =>
-                this.invokeStub.should.have.been.calledWithExactly(Test2, Sinon.match.any, undefined)
-            );
-            it("should store route in the locals map", () => {
-                expect(this.map.get(ExpressRouter)).to.be.eq("router");
-            });
         });
     });
 });

--- a/test/units/swagger/class/OpenApiEndpointBuilder.spec.ts
+++ b/test/units/swagger/class/OpenApiEndpointBuilder.spec.ts
@@ -13,7 +13,8 @@ describe("OpenApiParamsBuilder", () => {
         this.builder = new OpenApiEndpointBuilder(
             this.endpointMetadata,
             "/test",
-            {path: "/", "method": "get"}
+            {path: "/", "method": "get"},
+            (s: any) => s
         );
         // this.builder.build();
     });


### PR DESCRIPTION
Now all components (Controllers, Services, Factory, Converters, Model, etc...) are stored in the same registry. 

Next step is to implement containers. This feature will allow to create multiple server instance without side effect.

Unit test will be facilitated.