### PR TITLE
fix(mongoose): Ref decorator support string type for circular dependency

### DIFF
--- a/src/mongoose/decorators/ref.ts
+++ b/src/mongoose/decorators/ref.ts
@@ -1,6 +1,6 @@
+import {PropertyMetadata, PropertyRegistry} from "@tsed/common";
 import {Store} from "@tsed/core";
 import {Schema} from "mongoose";
-import {PropertyMetadata, PropertyRegistry} from "@tsed/common";
 import {MONGOOSE_MODEL_NAME, MONGOOSE_SCHEMA} from "../constants";
 
 export type Ref<T> = T | string;
@@ -32,12 +32,14 @@ export type Ref<T> = T | string;
  * @decorator
  * @mongoose
  */
-export function Ref(type: any) {
+export function Ref(type: string | any) {
     return PropertyRegistry.decorate((propertyMetadata: PropertyMetadata) => {
-        propertyMetadata.type = type;
+        if (typeof type !== "string") {
+            propertyMetadata.type = type;
+        }
         propertyMetadata.store.merge(MONGOOSE_SCHEMA, {
             type: Schema.Types.ObjectId,
-            ref: Store.from(type).get(MONGOOSE_MODEL_NAME)
+            ref: typeof type === "string" ? type : Store.from(type).get(MONGOOSE_MODEL_NAME)
         });
     });
 }

--- a/test/units/mongoose/decorators/ref.spec.ts
+++ b/test/units/mongoose/decorators/ref.spec.ts
@@ -6,22 +6,46 @@ import {Ref} from "../../../../src/mongoose/decorators";
 import {expect} from "../../../tools";
 
 describe("@Ref()", () => {
-    class Test {
-    }
 
-    class RefTest {
-    }
+    describe("type is a class", () => {
+        class Test {
+        }
 
-    before(() => {
-        Store.from(RefTest).set(MONGOOSE_MODEL_NAME, "RefTest");
-        Ref(RefTest)(Test, "test", descriptorOf(Test, "test"));
-        this.store = Store.from(Test, "test", descriptorOf(Test, "test"));
+        class RefTest {
+        }
+
+        before(() => {
+            Store.from(RefTest).set(MONGOOSE_MODEL_NAME, "RefTest");
+            Ref(RefTest)(Test, "test", descriptorOf(Test, "test"));
+            this.store = Store.from(Test, "test", descriptorOf(Test, "test"));
+        });
+
+        it("should set metadata", () => {
+            expect(this.store.get(MONGOOSE_SCHEMA)).to.deep.eq({
+                type: Schema.Types.ObjectId,
+                ref: "RefTest"
+            });
+        });
     });
 
-    it("should set metadata", () => {
-        expect(this.store.get(MONGOOSE_SCHEMA)).to.deep.eq({
-            type: Schema.Types.ObjectId,
-            ref: "RefTest"
+    describe("type is a string", () => {
+        class Test {
+        }
+
+        class RefTest {
+        }
+
+        before(() => {
+            Store.from(RefTest).set(MONGOOSE_MODEL_NAME, "RefTest");
+            Ref("RefTest")(Test, "test", descriptorOf(Test, "test"));
+            this.store = Store.from(Test, "test", descriptorOf(Test, "test"));
+        });
+
+        it("should set metadata", () => {
+            expect(this.store.get(MONGOOSE_SCHEMA)).to.deep.eq({
+                type: Schema.Types.ObjectId,
+                ref: "RefTest"
+            });
         });
     });
 });


### PR DESCRIPTION
#Closes: 340