### PR TITLE
feat(socketio): Add argument on Nsp decorator

### DIFF
--- a/docs/tutorials/socket-io.emd
+++ b/docs/tutorials/socket-io.emd
@@ -56,6 +56,10 @@ import {SocketService, IO, Nsp, Socket, SocketSession} from "@tsed/socketio";
 export class MySocketService {
 
     @Nsp nsp: SocketIO.Namespace;
+    
+    @Nsp("/my-other-namespace") 
+    nspOther: SocketIO.Namespace; // communication between two namespace
+
 
     constructor(@IO private io: SocketIO.Server) {}
     /**

--- a/src/socketio/decorators/nsp.ts
+++ b/src/socketio/decorators/nsp.ts
@@ -14,6 +14,9 @@ import {SocketFilter} from "./socketFilter";
  *   @Nsp
  *   nsp: SocketIO.Namespace; // will inject SocketIO.Namespace (not available on constructor)
  *
+ *   @Nsp("/my-other-namespace")
+ *   nspOther: SocketIO.Namespace; // communication between two namespace
+ *
  *   @Input("event")
  *   myMethod(@Nsp namespace: SocketIO.Namespace) {
  *
@@ -26,15 +29,24 @@ import {SocketFilter} from "./socketFilter";
  * @param {number} index
  * @decorator
  */
-export function Nsp(target: any, propertyKey: string, index?: number): any {
+export function Nsp(target: any, propertyKey?: string, index?: number): any {
+
+    if (typeof target === "string") {
+        const nsp = target as string;
+        return (target: any, propertyKey: string) => {
+            Store.from(target).merge("socketIO", {
+                injectNamespaces: [{propertyKey, nsp}]
+            });
+        };
+    }
 
     if (index === undefined) {
         Store.from(target).merge("socketIO", {
-            injectNamespace: propertyKey
+            injectNamespaces: [{propertyKey}]
         });
         return;
     }
 
-    return SocketFilter(SocketFilters.NSP)(target, propertyKey, index!);
+    return SocketFilter(SocketFilters.NSP)(target, propertyKey!, index!);
 }
 

--- a/src/socketio/interfaces/ISocketProviderMetadata.ts
+++ b/src/socketio/interfaces/ISocketProviderMetadata.ts
@@ -14,7 +14,7 @@ export enum SocketProviderTypes {
 export interface ISocketProviderMetadata {
     type: SocketProviderTypes;
     namespace?: string;
-    injectNamespace?: string;
+    injectNamespaces?: {propertyKey: string, nsp: string}[];
     useBefore?: any[];
     useAfter?: any[];
     handlers: {

--- a/src/socketio/readme.md
+++ b/src/socketio/readme.md
@@ -49,7 +49,10 @@ import {SocketService, IO, Nsp, Socket, SocketSession} from "@tsed/socketio";
 @SocketService("/my-namespace")
 export class MySocketService {
 
-    @Nsp nsp: SocketIO.Namespace;
+    @Nsp nsp: SocketIO.Namespace; 
+    
+    @Nsp("/my-other-namespace") 
+    nspOther: SocketIO.Namespace; // communication between two namespace
 
     constructor(@IO private io: SocketIO.Server) {}
     /**

--- a/src/socketio/services/SocketIOService.ts
+++ b/src/socketio/services/SocketIOService.ts
@@ -50,7 +50,7 @@ export class SocketIOService implements OnServerReady {
      *
      * @returns {Provider<any>[]}
      */
-    public getWebsocketServices(): Provider<any>[] {
+    protected getWebsocketServices(): Provider<any>[] {
         return Array.from(SocketServiceRegistry.values());
     }
 
@@ -85,11 +85,17 @@ export class SocketIOService implements OnServerReady {
      *
      * @param {Provider<any>} provider
      */
-    private bindProvider(provider: Provider<any>) {
+    protected bindProvider(provider: Provider<any>) {
         const wsConfig: ISocketProviderMetadata = provider.store.get("socketIO")!;
 
         const nspConfig = this.getNsp(wsConfig.namespace);
-        const builder = new SocketHandlersBuilder(provider).build(nspConfig.nsp);
+        const nsps = new Map();
+
+        this.namespaces.forEach((value, nsp) => {
+            nsps.set(nsp, value.nsp);
+        });
+
+        const builder = new SocketHandlersBuilder(provider).build(nsps);
 
         nspConfig.instances.push(builder);
     }
@@ -98,7 +104,7 @@ export class SocketIOService implements OnServerReady {
      *
      * @param logger
      */
-    private printSocketEvents(logger: { info: (s: any) => void } = $log) {
+    protected printSocketEvents(logger: { info: (s: any) => void } = $log) {
         const list = this.getWebsocketServices()
             .reduce((acc: any[], provider) => {
                 const {handlers, namespace}: ISocketProviderMetadata = provider.store.get("socketIO");

--- a/test/units/socketio/decorators/nsp.spec.ts
+++ b/test/units/socketio/decorators/nsp.spec.ts
@@ -40,7 +40,25 @@ describe("Nsp", () => {
 
         it("should set metadata", () => {
             expect(this.store.get("socketIO")).to.deep.eq({
-                injectNamespace: "test"
+                injectNamespaces: [{propertyKey: "test"}]
+            });
+        });
+    });
+
+
+    describe("when it used as property decorator with parameters", () => {
+        class Test {
+            @Nsp("/test")
+            property: any;
+        }
+
+        before(() => {
+            this.store = Store.from(Test);
+        });
+
+        it("should set metadata", () => {
+            expect(this.store.get("socketIO")).to.deep.eq({
+                injectNamespaces: [{propertyKey: "property", nsp: "/test"}]
             });
         });
     });


### PR DESCRIPTION
Argument given to Nsp decorator allow to inject on the property class (socket service),
a specific namespace (other than the default Namespace used by the socket service).

```typescript
import * as SocketIO from "socket.io";
import {SocketService, IO, Nsp, Socket, SocketSession} from "@tsed/socketio";

@SocketService("/my-namespace")
export class MySocketService {

    @Nsp nsp: SocketIO.Namespace;

    @Nsp("/my-other-namespace")
    nspOther: SocketIO.Namespace; // communication between two namespace

    constructor(@IO private io: SocketIO.Server) {}
    /**
     * Triggered the namespace is created
     */
    $onNamespaceInit(nsp: SocketIO.Namespace) {

    }
    /**
     * Triggered when a new client connects to the Namespace.
     */
    $onConnection(@Socket socket: SocketIO.Socket, @SocketSession session: SocketSession) {

    }
    /**
     * Triggered when a client disconnects from the Namespace.
     */
    $onDisconnect(@Socket socket: SocketIO.Socket) {

    }
}
```

Closes: #307
