### PR TITLE
feat(mongoose): decorators for select and schema.index()

### DIFF
--- a/src/mongoose/decorators/index.ts
+++ b/src/mongoose/decorators/index.ts
@@ -7,3 +7,4 @@ export * from "./preHook";
 export * from "./ref";
 export * from "./schema";
 export * from "./unique";
+export * from "./select";

--- a/src/mongoose/decorators/index.ts
+++ b/src/mongoose/decorators/index.ts
@@ -1,6 +1,7 @@
 export * from "./indexed";
 export * from "./model";
 export * from "./mongoosePlugin";
+export * from "./mongooseIndex";
 export * from "./postHook";
 export * from "./preHook";
 export * from "./ref";

--- a/src/mongoose/decorators/mongooseIndex.ts
+++ b/src/mongoose/decorators/mongooseIndex.ts
@@ -1,0 +1,34 @@
+import {applySchemaOptions} from "../utils/schemaOptions";
+
+/**
+ * Calls schema.index() to define an index (most likely compound) for the schema.
+ *
+ * ### Example
+ *
+ * ```typescript
+ * @Model()
+ * @MongooseIndex({first: 1, second: 1}, {unique: 1})
+ * export class EventModel {
+ *
+ *   @Property()
+ *   first: string;
+ *
+ *   @Property()
+ *   second: string;
+ *
+ * }
+ * ```
+ *
+ * @param fields
+ * @param options
+ * @returns {Function}
+ * @decorator
+ * @mongoose
+ */
+export function MongooseIndex(fields: object, options: any): Function {
+  return (target: any) => {
+    applySchemaOptions(target, {
+      indexes: [{fields, options}]
+    });
+  };
+}

--- a/src/mongoose/decorators/select.ts
+++ b/src/mongoose/decorators/select.ts
@@ -1,0 +1,23 @@
+import {Schema} from "./schema";
+
+/**
+ * Tells Mongoose to set default select() behavior for this path.
+ *
+ * ### Example
+ *
+ * ```typescript
+ * @Model()
+ * export class EventModel {
+ *   @Select()
+ *   field: string;
+ * }
+ * ```
+ *
+ * @param {boolean | any} select
+ * @returns {Function}
+ * @decorator
+ * @mongoose
+ */
+export function Select(select: boolean | any = true) {
+  return Schema({select});
+}

--- a/src/mongoose/interfaces/MongooseModelOptions.ts
+++ b/src/mongoose/interfaces/MongooseModelOptions.ts
@@ -55,12 +55,21 @@ export interface MongoosePluginOptions {
 /**
  *
  */
+export interface MongooseIndexOptions {
+  fields: object;
+  options?: any;
+}
+
+/**
+ *
+ */
 export interface MongooseModelOptions {
   schemaOptions?: SchemaOptions;
   name?: string;
   collection?: string;
   skipInit?: boolean;
   plugins?: MongoosePluginOptions[];
+  indexes?: MongooseIndexOptions[];
   pre?: MongoosePreHook[];
   post?: MongoosePostHook[];
 }

--- a/src/mongoose/utils/schemaOptions.ts
+++ b/src/mongoose/utils/schemaOptions.ts
@@ -54,6 +54,10 @@ export function applySchemaOptions(target: any, options: MongooseModelOptions) {
       }
     }
 
+    if (options.indexes) {
+      options.indexes.forEach(item => schema.index(item.fields, item.options));
+    }
+
     if (options.pre) {
       options.pre.forEach(item => schema.pre(item.method, !!item.parallel, buildPreHook(item.fn), item.errorCb));
     }

--- a/test/units/mongoose/decorators/mongooseIndex.spec.ts
+++ b/test/units/mongoose/decorators/mongooseIndex.spec.ts
@@ -1,0 +1,28 @@
+import {MongooseIndex} from "../../../../src/mongoose/decorators/mongooseIndex";
+import * as mod from "../../../../src/mongoose/utils/schemaOptions";
+import {Sinon} from "../../../tools";
+
+describe("@MongooseIndex()", () => {
+  class Test {}
+
+  before(() => {
+    this.applySchemaOptionsStub = Sinon.stub(mod, "applySchemaOptions");
+    this.fields = {};
+    MongooseIndex("fields" as any, "options" as any)(Test);
+  });
+
+  after(() => {
+    this.applySchemaOptionsStub.restore();
+  });
+
+  it("should call applySchemaOptions", () => {
+    this.applySchemaOptionsStub.should.have.been.calledWithExactly(Test, {
+      indexes: [
+        {
+          fields: "fields",
+          options: "options"
+        }
+      ]
+    });
+  });
+});

--- a/test/units/mongoose/decorators/select.spec.ts
+++ b/test/units/mongoose/decorators/select.spec.ts
@@ -1,0 +1,20 @@
+import {Store} from "../../../../src/core/class/Store";
+import {descriptorOf} from "../../../../src/core/utils";
+import {Select} from "../../../../src/mongoose/decorators";
+import {expect} from "../../../tools";
+import {MONGOOSE_SCHEMA} from "../../../../src/mongoose/constants";
+
+describe("@Select()", () => {
+  class Test {}
+
+  before(() => {
+    Select()(Test, "test", descriptorOf(Test, "test"));
+    this.store = Store.from(Test, "test", descriptorOf(Test, "test"));
+  });
+
+  it("should set metadata", () => {
+    expect(this.store.get(MONGOOSE_SCHEMA)).to.deep.eq({
+      select: true
+    });
+  });
+});

--- a/test/units/mongoose/utils/schemaOptions.spec.ts
+++ b/test/units/mongoose/utils/schemaOptions.spec.ts
@@ -66,7 +66,8 @@ describe("schemaOptions", () => {
       this.schema = {
         pre: Sinon.stub(),
         post: Sinon.stub(),
-        plugin: Sinon.stub()
+        plugin: Sinon.stub(),
+        index: Sinon.stub()
       };
 
       Store.from(Test).set(MONGOOSE_SCHEMA, this.schema);
@@ -86,7 +87,8 @@ describe("schemaOptions", () => {
             fn: "fn"
           }
         ],
-        plugins: [{plugin: "plugin", options: "options"}]
+        plugins: [{plugin: "plugin", options: "options"}],
+        indexes: [{fields: "fields", options: "options"}]
       } as any);
     });
 
@@ -100,6 +102,10 @@ describe("schemaOptions", () => {
 
     it("should call schema.plugin", () => {
       this.schema.plugin.should.have.been.calledWithExactly("plugin", "options");
+    });
+
+    it("should call schema.index", () => {
+      this.schema.index.should.have.been.calledWithExactly("fields", "options");
     });
   });
 });


### PR DESCRIPTION
## Description
Add two mongoose decorators to:
 - define schema indexes
 - set default select() behavior for schema path

## Usage example

Calls schema.index() to define an index (most likely compound) for the schema.

```typescript
@Model()
@MongooseIndex({first: 1, second: 1}, {unique: 1})
export class EventModel {

  @Property()
  first: string;

  @Property()
  second: string;

 }
```

Tells Mongoose to set default select() behavior for this path.

```typescript
@Model()
export class EventModel {
  @Select(false)
  field: string;
}
```
