### PR TITLE
feat(multipartfile): Add field name support for file upload

### DIFF
--- a/docs/tutorials/upload-files-with-multer.md
+++ b/docs/tutorials/upload-files-with-multer.md
@@ -56,17 +56,19 @@ Ts.ED use multer to handler file uploads. Single file can be injected like this:
 
 ```typescript
 import {Controller, Post} from "@tsed/common";
+import {MultipartFile, MulterOptions} from "@tsed/multipartfiles";
 
 @Controller('/')
 class MyCtrl {
     
   @Post('/file')
-  private uploadFile(@MultipartFile() file: Express.Multer.File) {
+  private uploadFile(@MultipartFile('file') file: Express.Multer.File) {
 
   }
      
   @Post('/file')
-  private uploadFile(@MultipartFile({dest: "/other-dir"}) file: Express.Multer.File) {
+  @MulterOptions({dest: "/other-dir"})
+  private uploadFile(@MultipartFile('file') file: Express.Multer.File) {
          
   }
 }
@@ -80,11 +82,12 @@ import {MultipartFile} from "@tsed/multipartfiles";
 @Controller('/')
 class MyCtrl {
   @Post('/files')
-  private uploadFile(@MultipartFile() files: Express.Multer.File[]) {
-
+  private uploadFile(@MultipartFile("files", 4) files: Express.Multer.File[]) {
+    // multiple files with 4 as limits
   }
 }
 ```
+!> Note: Swagger spec (v2.0) doesn't support multiple files.
 
 <div class="guide-links">
 <a href="#/tutorials/custom-validator">Custom validator</a>

--- a/src/core/utils/getValue.ts
+++ b/src/core/utils/getValue.ts
@@ -1,4 +1,4 @@
-import {isCollection} from "./ObjectUtils";
+import {isCollection, isArray} from "./ObjectUtils";
 
 /**
  *
@@ -12,7 +12,7 @@ export function getValue(expression: string, scope: any, defaultValue?: any, sep
   const keys: string[] = expression.split(separator);
 
   const getValue = (key: string) => {
-    if (isCollection(scope)) {
+    if (isCollection(scope) && !isArray(scope)) {
       return scope.get(key);
     }
 

--- a/src/core/utils/setValue.ts
+++ b/src/core/utils/setValue.ts
@@ -1,11 +1,11 @@
-import {isCollection} from "./ObjectUtils";
+import {isArray, isCollection} from "./ObjectUtils";
 
 export function setValue(expression: string, value: any, scope: any, separator = ".") {
   const keys: string[] = expression.split(separator);
 
   const setValue = (key: string, add: boolean) => {
     if (add) {
-      if (isCollection(scope)) {
+      if (isCollection(scope) && !isArray(scope)) {
         scope.set(key, value);
       } else {
         scope[key] = value;

--- a/src/multipartfiles/components/MultipartFilesFilter.ts
+++ b/src/multipartfiles/components/MultipartFilesFilter.ts
@@ -1,4 +1,5 @@
 import {Filter, IFilter} from "@tsed/common";
+import {getValue} from "@tsed/core";
 
 /**
  * @private
@@ -7,6 +8,10 @@ import {Filter, IFilter} from "@tsed/common";
 @Filter()
 export class MultipartFilesFilter implements IFilter {
   transform(expression: string, request: any, response: any) {
+    if (expression) {
+      return getValue(expression, request["files"]);
+    }
+
     return request["files"];
   }
 }

--- a/src/multipartfiles/decorators/multerOptions.ts
+++ b/src/multipartfiles/decorators/multerOptions.ts
@@ -1,0 +1,61 @@
+import {getDecoratorType, Store} from "@tsed/core";
+import * as Multer from "multer";
+import {MultipartFileMiddleware} from "../middlewares/MultipartFileMiddleware";
+
+/**
+ * Define a parameter as Multipart file.
+ *
+ * ```typescript
+ * import {Controller, Post} from "@tsed/common";
+ * import {MulterOptions, MultipartFile} from "@tsed/multipartfiles";
+ * import {Multer} from "@types/multer";
+ *
+ * type MulterFile = Express.Multer.File;
+ *
+ * @Controller('/')
+ * class MyCtrl {
+ *   @Post('/file')
+ *   private uploadFile(@MultipartFile("file1", 2) file: MulterFile) {
+ *
+ *   }
+ *
+ *   @Post('/file')
+ *   private uploadFile(@MultipartFile("file1", {dest: "/other-dir"}) file: MulterFile) {
+ *
+ *   }
+ *
+ *   @Post('/file2')
+ *   @MulterOptions({dest: "/other-dir"})
+ *   private uploadFile(@MultipartFile("file1") file: MulterFile, @MultipartFile("file2") file2: MulterFile) {
+ *
+ *   }
+ *
+ *   @Post('/files')
+ *   private uploadFile(@MultipartFile("file1") files: MulterFile[]) {
+ *
+ *   }
+ * }
+ * ```
+ *
+ * > See the tutorial on the [multer configuration](tutorials/upload-files-with-multer.md).
+ * @param {multer.Options} options
+ * @returns {(target: any, propertyKey: string, descriptor: PropertyDescriptor) => PropertyDescriptor}
+ * @decorator
+ * @multer
+ */
+export function MulterOptions(options: Multer.Options) {
+  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+    const type = getDecoratorType([target, propertyKey, descriptor], true);
+
+    switch (type) {
+      default:
+        throw new Error("MulterOptions is only supported on method");
+      case "method":
+        Store.fromMethod(target, propertyKey).merge(MultipartFileMiddleware, {
+          options
+        });
+
+        return descriptor;
+    }
+  };
+}

--- a/src/multipartfiles/index.ts
+++ b/src/multipartfiles/index.ts
@@ -4,6 +4,8 @@ import * as multer from "multer";
 declare interface IServerSettings {
   multer?: multer.Options;
 }
+
 // tslint:enable: no-unused-variable
 
 export * from "./decorators/multipartFile";
+export * from "./decorators/multerOptions";

--- a/src/multipartfiles/package.json
+++ b/src/multipartfiles/package.json
@@ -5,15 +5,16 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "dependencies": {
-    "tslib": "^1.9.0"
+    "tslib": "^1.9.0",
+    "multer": "^1.3.0"
   },
   "peerDependencies": {
-    "@types/multer": "^1.3.6",
-    "multer": "^1.3.0",
+    "@types/multer": "^1.3.7",
     "@tsed/core": "0.0.0-PLACEHOLDER",
     "@tsed/common": "0.0.0-PLACEHOLDER"
   },
-  "devDependencies": {},
+  "devDependencies": {
+  },
   "private": false,
   "directories": {
     "lib": "lib",

--- a/src/multipartfiles/readme.md
+++ b/src/multipartfiles/readme.md
@@ -7,7 +7,7 @@ A package of Ts.ED framework. See website: https://romakita.github.io/ts-express
 Before using the `@MultipartFile()` you must install [multer](https://github.com/expressjs/multer) module on your project:
 
 ```bash
-npm install --save multer @types/multer @tsed/multipartfiles
+npm install --save @types/multer @tsed/multipartfiles
 ```
 
 Then import `@tsed/multipartfiles` in your [ServerLoader](api/common/server/serverloader.md):
@@ -55,6 +55,8 @@ Ts.ED use multer to handler file uploads. Single file can be injected like this:
 ```typescript
 import {Controller, Post} from "@tsed/common";
 import {Multer} from "@types/multer";
+import {MultipartFile, MulterOptions} from "@tsed/multipartfiles";
+
 
 type MulterFile = Express.Multer.File;
 
@@ -62,30 +64,39 @@ type MulterFile = Express.Multer.File;
 class MyCtrl {
     
   @Post('/file')
-  private uploadFile(@MultipartFile() file: MulterFile) {
+  private uploadFile(@MultipartFile("file") file: MulterFile) {
 
   }
      
   @Post('/file')
-  private uploadFile(@MultipartFile({dest: "/other-dir"}) file: MulterFile) {
+  @MulterOptions({dest: "/other-dir"})
+  private uploadFile(@MultipartFile("file") file: MulterFile) {
          
+  }
+
+  @Post('/file')
+  @MulterOptions({dest: "/other-dir"})
+  private uploadFile(@MultipartFile("file1") file1: MulterFile, @MultipartFile("file2") file2: MulterFile) {
+
   }
 }
 ```
 
 For multiple files, just add Array type annotation like this:
+
 ```typescript
 import {Controller, Post} from "@tsed/common";
 import {Multer} from "multer";
-import {MultipartFile} from "@tsed/multipartfile";
+import {MultipartFile, MulterOptions} from "@tsed/multipartfiles";
 
 type MulterFile = Express.Multer.File;
 
 @Controller('/')
 class MyCtrl {
   @Post('/files')
-  private uploadFile(@MultipartFile() files: MulterFile[]) {
-
+  @MulterOptions({dest: "/other-dir"})
+  private uploadFile(@MultipartFile("files", 4) files: MulterFile[]) {
+      // multiple files with 4 as limits
   }
 }
 ```

--- a/src/swagger/class/OpenApiParamsBuilder.ts
+++ b/src/swagger/class/OpenApiParamsBuilder.ts
@@ -80,6 +80,7 @@ export class OpenApiParamsBuilder extends OpenApiModelSchemaBuilder {
 
           case ParamTypes.FORM_DATA:
             return Object.assign(this.createBaseParameter(param), param.store.get("schema"), {
+              name: ((param.expression as string) || "").replace(".0", ""),
               type: "file"
             });
         }

--- a/src/swagger/decorators/consumes.ts
+++ b/src/swagger/decorators/consumes.ts
@@ -21,7 +21,7 @@ import {Operation} from "./operation";
  */
 export function Consumes(...consumes: string[]) {
   return (...args: any[]) => {
-    const type = getDecoratorType(args);
+    const type = getDecoratorType(args, true);
     switch (type) {
       case "method":
         return Operation({consumes})(...args);

--- a/test/integration/app/controllers/calendars/CalendarCtrl.ts
+++ b/test/integration/app/controllers/calendars/CalendarCtrl.ts
@@ -1,4 +1,3 @@
-import * as Express from "express";
 import {
   Authenticated,
   BodyParams,
@@ -23,6 +22,7 @@ import {
 } from "@tsed/common";
 import {MultipartFile} from "@tsed/multipartfiles";
 import {Deprecated, Description, Returns, Security} from "@tsed/swagger";
+import * as Express from "express";
 import {CalendarModel} from "../../models/Calendar";
 import {TokenService} from "../../services/TokenService";
 import {BaseController} from "../base/BaseController";
@@ -284,12 +284,14 @@ export class CalendarCtrl extends BaseController {
   }
 
   @Post("/documents")
-  testMultipart(@MultipartFile() files: any[]) {
+  testMultipart(@MultipartFile("files") files: any[]) {
     return files;
   }
 
   @Post("/documents/1")
-  testMultipart2(@MultipartFile() file: any) {
-    return file;
+  testMultipart2(@MultipartFile("file1") file: any) {
+    console.log("====>", file);
+
+    return "DONE";
   }
 }

--- a/test/integration/data/swagger.spec.json
+++ b/test/integration/data/swagger.spec.json
@@ -756,6 +756,7 @@
         "parameters": [
           {
             "in": "formData",
+            "name": "files",
             "required": false,
             "type": "file"
           }
@@ -781,6 +782,7 @@
         "parameters": [
           {
             "in": "formData",
+            "name": "file1",
             "required": false,
             "type": "file"
           }

--- a/test/units/multipartfiles/decorators/multerOptions.spec.ts
+++ b/test/units/multipartfiles/decorators/multerOptions.spec.ts
@@ -1,0 +1,39 @@
+import {descriptorOf, Store} from "@tsed/core";
+import {MulterOptions} from "../../../../src/multipartfiles";
+import {MultipartFileMiddleware} from "../../../../src/multipartfiles/middlewares/MultipartFileMiddleware";
+import {expect} from "../../../tools";
+
+class Test {
+  test() {}
+}
+
+describe("@MulterOptions()", () => {
+  describe("when success", () => {
+    before(() => {
+      MulterOptions({dest: "/"})(Test.prototype, "test", descriptorOf(Test.prototype, "test"));
+      this.store = Store.fromMethod(Test.prototype, "test");
+    });
+
+    it("should store metadata", () => {
+      expect(this.store.get(MultipartFileMiddleware)).to.deep.equal({
+        options: {
+          dest: "/"
+        }
+      });
+    });
+  });
+
+  describe("when error", () => {
+    before(() => {
+      try {
+        MulterOptions({dest: "/"})(Test, "test", {});
+      } catch (er) {
+        this.error = er;
+      }
+    });
+
+    it("should store metadata", () => {
+      expect(this.error.message).to.eq("MulterOptions is only supported on method");
+    });
+  });
+});

--- a/test/units/multipartfiles/filters/MultipartFileFilter.spec.ts
+++ b/test/units/multipartfiles/filters/MultipartFileFilter.spec.ts
@@ -22,19 +22,43 @@ describe("MultipartFileFilter", () => {
 });
 
 describe("MultipartFilesFilter", () => {
-  before(
-    inject([MultipartFilesFilter], (filter: MultipartFilesFilter) => {
-      this.filter = filter;
-    })
-  );
+  describe("legacy", () => {
+    before(
+      inject([MultipartFilesFilter], (filter: MultipartFilesFilter) => {
+        this.filter = filter;
+      })
+    );
 
-  describe("transform()", () => {
-    before(() => {
-      this.result = this.filter.transform("", {files: [{}]});
+    describe("transform()", () => {
+      before(() => {
+        this.result = this.filter.transform("", {files: [{}]});
+      });
+
+      it("should transform expression", () => {
+        expect(this.result).to.be.an("array");
+      });
     });
+  });
 
-    it("should transform expression", () => {
-      expect(this.result).to.be.an("array");
+  describe("new feature", () => {
+    before(
+      inject([MultipartFilesFilter], (filter: MultipartFilesFilter) => {
+        this.filter = filter;
+      })
+    );
+
+    describe("transform()", () => {
+      before(() => {
+        this.result = this.filter.transform("test", {
+          files: {
+            test: []
+          }
+        });
+      });
+
+      it("should transform expression", () => {
+        expect(this.result).to.be.an("array");
+      });
     });
   });
 });

--- a/test/units/multipartfiles/middlewares/MultiparFileMiddleware.spec.ts
+++ b/test/units/multipartfiles/middlewares/MultiparFileMiddleware.spec.ts
@@ -1,36 +1,38 @@
 import {MultipartFileMiddleware} from "../../../../src/multipartfiles/middlewares/MultipartFileMiddleware";
-import {FakeRequest} from "../../../helper/FakeRequest";
-import {FakeResponse} from "../../../helper/FakeResponse";
-import {$logStub, Sinon} from "../../../tools";
+import {Sinon} from "../../../tools";
 
 describe("MultipartFileMiddleware", () => {
-  before(() => {
-    this.settings = {
-      uploadDir: "/",
-      get: Sinon.stub()
-        .withArgs("multer")
-        .returns({options: "options"})
-    };
-    this.middleware = new MultipartFileMiddleware(this.settings);
-    this.expressMiddleware = Sinon.stub();
-
-    this.middleware.multer = Sinon.stub().returns({
-      any: Sinon.stub().returns(this.expressMiddleware)
-    });
-
-    this.nextSpy = Sinon.spy();
-    this.request = new FakeRequest();
-    this.response = new FakeResponse();
-    this.fakeEndpoint = {
-      store: {
-        get: Sinon.stub()
-      }
-    };
-  });
-
-  describe("with multer module", () => {
+  describe("legacy", () => {
     before(() => {
-      this.middleware.use(this.fakeEndpoint, this.request, this.response, this.nextSpy);
+      this.settings = {
+        uploadDir: "/",
+        get: Sinon.stub()
+          .withArgs("multer")
+          .returns({options: "options"})
+      };
+      this.middleware = new MultipartFileMiddleware(this.settings);
+      this.expressMiddleware = Sinon.stub();
+      this.middleware.multer = Sinon.stub().returns({
+        any: Sinon.stub().returns(this.expressMiddleware)
+      });
+
+      this.nextSpy = Sinon.stub();
+
+      this.middleware.use(
+        {
+          store: {
+            get() {
+              return {
+                options: {options: "options"},
+                any: true
+              };
+            }
+          }
+        },
+        {request: "request"},
+        {response: "response"},
+        this.nextSpy
+      );
     });
 
     it("should call multer with some options", () => {
@@ -38,21 +40,63 @@ describe("MultipartFileMiddleware", () => {
     });
 
     it("should create middleware and call it", () => {
-      this.expressMiddleware.should.be.calledWithExactly(this.request, this.response, this.nextSpy);
+      this.expressMiddleware.should.be.calledWithExactly({request: "request"}, {response: "response"}, this.nextSpy);
     });
   });
 
-  describe("without multer module", () => {
+  describe("new feature", () => {
     before(() => {
-      $logStub.reset();
-      delete this.middleware.multer;
-      this.middleware.use(this.fakeEndpoint, this.request, this.response, this.nextSpy);
+      this.settings = {
+        uploadDir: "/",
+        get: Sinon.stub()
+          .withArgs("multer")
+          .returns({options: "options"})
+      };
+      this.middleware = new MultipartFileMiddleware(this.settings);
+      this.expressMiddleware = Sinon.stub();
+      this.multerApiStub = {
+        fields: Sinon.stub().returns(this.expressMiddleware)
+      };
+
+      this.middleware.multer = Sinon.stub().returns(this.multerApiStub);
+
+      this.nextSpy = Sinon.stub();
+
+      this.middleware.use(
+        {
+          store: {
+            get() {
+              return {
+                options: {options: "options"},
+                fields: [{name: "test"}, {name: "test1", maxCount: 4}]
+              };
+            }
+          }
+        },
+        {request: "request"},
+        {response: "response"},
+        this.nextSpy
+      );
     });
 
-    it("should emit a warning", () => {
-      $logStub.warn.should.be.calledWithExactly(
-        "Multer isn't installed ! Run npm install --save multer before using Multipart decorators."
-      );
+    it("should call multer with some options", () => {
+      this.middleware.multer.should.have.been.calledWithExactly({dest: "/", options: "options"});
+    });
+
+    it("should call multer.field()", () => {
+      this.multerApiStub.fields.should.have.been.calledWithExactly([
+        {
+          maxCount: undefined,
+          name: "test"
+        },
+        {
+          maxCount: 4,
+          name: "test1"
+        }
+      ]);
+    });
+    it("should create middleware and call it", () => {
+      this.expressMiddleware.should.have.been.calledWithExactly({request: "request"}, {response: "response"}, this.nextSpy);
     });
   });
 });

--- a/test/units/swagger/decorators/consumes.spec.ts
+++ b/test/units/swagger/decorators/consumes.spec.ts
@@ -10,8 +10,8 @@ class Test {
 describe("Consumes()", () => {
   describe("when is used as method decorator", () => {
     before(() => {
-      Consumes("text/html")(Test, "test", descriptorOf(Test, "test"));
-      this.store = Store.from(Test, "test", descriptorOf(Test, "test"));
+      Consumes("text/html")(Test.prototype, "test", descriptorOf(Test, "test"));
+      this.store = Store.from(Test.prototype, "test", descriptorOf(Test, "test"));
     });
     it("should set the produces", () => {
       expect(this.store.get("operation").consumes).to.deep.eq(["text/html"]);


### PR DESCRIPTION
- Add name field support (`@MultipartFile('fieldName')`)
- Add `@MulterOptions()` decorator usable on method to configure specific multer options
- Improve Swagger documentation support

Closes: #398 

## Examples
```typescript
import {Controller, Post} from "@tsed/common";
import {MultipartFile, MulterOptions} from "@tsed/multipartfiles";

@Controller('/')
class MyCtrl {
    
  @Post('/file')
  private uploadFile(@MultipartFile('file') file: Express.Multer.File) {

  }
     
  @Post('/file')
  @MulterOptions({dest: "/other-dir"})
  private uploadFile(@MultipartFile('file') file: Express.Multer.File) {
         
  }
}
```