### PR TITLE
Removed render decorator

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -230,7 +230,6 @@ export interface Calendar{
 export class CalendarCtrl {
 
     @Get("/")
-    @Render("calendars/index")
     async renderCalendars(): Promise<Array<Calendar>> {
         return [{id: '1', name: "test"}];
     }


### PR DESCRIPTION
Copy-pasting tutorial broke with `Error: No default engine was specified and no extension was provided.`.