### PR TITLE
feat: post api allows formData in body When api consumes application/…

### DIFF
--- a/packages/swagger/src/class/OpenApiParamsBuilder.ts
+++ b/packages/swagger/src/class/OpenApiParamsBuilder.ts
@@ -1,5 +1,5 @@
 import {ParamMetadata, ParamRegistry, ParamTypes} from "@tsed/common";
-import {deepExtends, nameOf, Type} from "@tsed/core";
+import {deepExtends, nameOf, Type, Store} from "@tsed/core";
 import {BodyParameter, FormDataParameter, HeaderParameter, Parameter, PathParameter, QueryParameter, Schema} from "swagger-schema-official";
 import {swaggerType} from "../utils";
 import {OpenApiModelSchemaBuilder} from "./OpenApiModelSchemaBuilder";
@@ -26,6 +26,12 @@ export class OpenApiParamsBuilder extends OpenApiModelSchemaBuilder {
 
       return !param.store.get("hidden");
     });
+
+    const fromMethod = Store.fromMethod(target, methodClassName);
+    const operation = fromMethod.get("operation");
+    if (operation && operation.consumes && operation.consumes.indexOf("application/x-www-form-urlencoded") > -1) {
+      this.hasFormData = true;
+    }
   }
 
   /**

--- a/test/units/swagger/class/OpenApiParamsBuilder.spec.ts
+++ b/test/units/swagger/class/OpenApiParamsBuilder.spec.ts
@@ -4,6 +4,7 @@ import {BodyParamsFilter} from "../../../../packages/common/src/filters/componen
 import {OpenApiParamsBuilder} from "../../../../packages/swagger/src/class/OpenApiParamsBuilder";
 import {expect, Sinon} from "../../../tools";
 import {Ctrl, SwaFoo2} from "./helpers/classes";
+import {Store} from "@tsed/core";
 
 const param0 = new ParamMetadata(Ctrl, "test", 0);
 param0.service = BodyParamsFilter;
@@ -12,6 +13,106 @@ param0.type = SwaFoo2;
 
 describe("OpenApiParamsBuilder", () => {
   describe("build()", () => {
+    describe("when consumes has application/x-www-form-urlencoded", () => {
+      before(() => {
+        const storeGet = (key: string) => {
+          if (key === "hidden") {
+            return false;
+          }
+
+          return {test: "test"};
+        };
+
+        this.params = [
+          {
+            paramType: ParamTypes.BODY,
+            expression: "expression1",
+            required: true,
+            store: {
+              get: storeGet
+            }
+          }
+        ];
+
+        class FakeMetadata {
+          attr1: any;
+          attr2: any;
+
+          constructor(public target: any) {}
+
+          test() {
+            return this.target;
+          }
+        }
+
+        this.store = new Store([FakeMetadata]);
+        this.store._map = new Map();
+        this.store._map.set("operation", {consumes: ["application/x-www-form-urlencoded"]});
+
+        this.getParamsStub = Sinon.stub(ParamRegistry, "getParams").returns(this.params);
+        this.fromMethodStub = Sinon.stub(Store, "fromMethod").returns(this.store);
+
+        this.builder = new OpenApiParamsBuilder(Ctrl, "test");
+      });
+      after(() => {
+        this.getParamsStub.restore();
+        this.fromMethodStub.restore();
+      });
+      it("should set hasFromData to true", () => {
+        expect(this.builder.hasFormData).to.equal(true);
+      });
+    });
+
+    describe("when consumes does not have application/x-www-form-urlencoded", () => {
+      before(() => {
+        const storeGet = (key: string) => {
+          if (key === "hidden") {
+            return false;
+          }
+
+          return {test: "test"};
+        };
+
+        this.params = [
+          {
+            paramType: ParamTypes.BODY,
+            expression: "expression1",
+            required: true,
+            store: {
+              get: storeGet
+            }
+          }
+        ];
+
+        class FakeMetadata {
+          attr1: any;
+          attr2: any;
+
+          constructor(public target: any) {}
+
+          test() {
+            return this.target;
+          }
+        }
+
+        this.store = new Store([FakeMetadata]);
+        this.store._map = new Map();
+        this.store._map.set("operation", {consumes: ["application/json"]});
+
+        this.getParamsStub = Sinon.stub(ParamRegistry, "getParams").returns(this.params);
+        this.fromMethodStub = Sinon.stub(Store, "fromMethod").returns(this.store);
+
+        this.builder = new OpenApiParamsBuilder(Ctrl, "test");
+      });
+      after(() => {
+        this.getParamsStub.restore();
+        this.fromMethodStub.restore();
+      });
+      it("should set hasFromData to false", () => {
+        expect(this.builder.hasFormData).to.equal(false);
+      });
+    });
+
     describe("when formData", () => {
       before(() => {
         const storeGet = (key: string) => {


### PR DESCRIPTION
## Description

There is currently no way to create endpoint which consumes parameters as fromData without file upload in the body. Using content-type "application/x-www-form-urlencoded" on decorator Consumes  will produce swagger with parameters type of formData.

```json
{
    "parameters": [{
         "in": "body",
         "name": "someName"
    }]
}
```

now becomes: 
```json
{
    "parameters": [{
         "in": "fromData",
         "name": "someName"
    }]
}
```
## Usage example

Using api consumes content type application/x-www-form-urlencoded with Operation, body parameters will be type of  formData:
```typescript
@Name('oauth2')
@Controller('')
export class PublicController {
    @Operation({ consumes: ['application/x-www-form-urlencoded'] })
    @Returns(200, { description: 'Returns authenticated token data' })
    public async token(@BodyParams('client_id') clientId: string): Promise<void> {
        //
    }
}

```
