### PR TITLE
fix(di): get symbol description instead of its constructor

### DIFF
--- a/packages/common/src/di/class/Provider.ts
+++ b/packages/common/src/di/class/Provider.ts
@@ -1,4 +1,4 @@
-import {getClass, nameOf, NotEnumerable, Store, Type} from "@tsed/core";
+import {getClass, getClassOrSymbol, nameOf, NotEnumerable, RegistryKey, Store, Type} from "@tsed/core";
 import {ProviderScope} from "../interfaces";
 import {IProvider} from "../interfaces/IProvider";
 import {ProviderType} from "../interfaces/ProviderType";
@@ -16,8 +16,10 @@ export class Provider<T> implements IProvider<T> {
   @NotEnumerable()
   private _store: Store;
 
-  constructor(protected _provide: any) {
-    this._provide = getClass(this._provide);
+  protected _provide: RegistryKey;
+
+  constructor(provide: RegistryKey) {
+    this._provide = getClassOrSymbol(provide);
     this._useClass = getClass(this._provide);
     this._store = Store.from(this._provide);
   }

--- a/test/units/di/class/Provider.spec.ts
+++ b/test/units/di/class/Provider.spec.ts
@@ -5,44 +5,50 @@ class T1 {}
 
 class T2 {}
 
-describe("Provider", () => {
-  before(() => {
-    this.provider = new Provider(T1);
-  });
+const S1 = Symbol.for("S1");
+const S2 = Symbol.for("S2");
 
+describe("Provider", () => {
   describe("className", () => {
     it("should return the class name", () => {
-      expect(this.provider.className).to.eq("T1");
+      expect(new Provider(T1).className).to.eq("T1");
+    });
+
+    it("should return the symbol name", () => {
+      expect(new Provider(S1).className).to.eq("S1");
     });
   });
 
   describe("provide", () => {
     it("should equal to the class provided", () => {
-      this.provider.provide = T2;
-      expect(this.provider.provide).to.equal(T2);
+      expect(new Provider(T2).provide).to.equal(T2);
+    });
+
+    it("should equal to the symbol provided", () => {
+      expect(new Provider(S2).provide).to.equal(S2);
     });
   });
 
   describe("useClass", () => {
     it("should not equal to the class provided", () => {
-      this.provider.provide = class {};
-      expect(this.provider.provide).not.to.equal(T2);
+      expect(new Provider(class {}).provide).not.to.equal(T2);
     });
   });
 
   describe("instance", () => {
     it("should have an instance", () => {
-      this.provider.provide = T1;
-      this.provider.useClass = T2;
-      this.provider.instance = new this.provider.useClass();
-      expect(this.provider.instance).instanceOf(T2);
+      const provider = new Provider(T1);
+      provider.useClass = T2;
+      provider.instance = new provider.useClass();
+      expect(provider.instance).instanceOf(T2);
     });
   });
 
   describe("type", () => {
     it("should set a type of provider", () => {
-      this.provider.type = "typeTest";
-      expect(this.provider.type).to.equal("typeTest");
+      const provider = new Provider(T1);
+      provider.type = "typeTest";
+      expect(provider.type).to.equal("typeTest");
     });
   });
 });


### PR DESCRIPTION
<!-- This template it's just here to help you for write your Pull Request -->

## Informations

Type | Migration
---|---
Fix | No

****

## Description
Provider uses constructor symbol instead of its description. This results in that `InjectorService` creates few instances on one provider. 

See following example:

```typescript
import {InjectorService} from "@tsed/common";

export interface DummyService {
   noop(): void;
}

export const DummyService = Symbol("DummyService");

export class DummyServiceImp {}

registerProvider({provide: DummyService, userClass: DummyServiceImp});

export interface DummyService2 {
   noop(): void;
}

export const DummyService2 = Symbol("DummyService2");

export class DummyService2Imp {}

registerProvider({provide: DummyService2, userClass: DummyService2Imp});
```
### Expected behavior: 

If I try to call `InjectorService.load()` method it builds 2 instances for following class DummyService2Imp and DummyServiceImp.

### Actual behavior:

It builds instances more than enough.