### PR TITLE
Mongoose models fixes and virtual refenreces

### DIFF
--- a/packages/mongoose/src/decorators/index.ts
+++ b/packages/mongoose/src/decorators/index.ts
@@ -6,5 +6,6 @@ export * from "./postHook";
 export * from "./preHook";
 export * from "./ref";
 export * from "./schema";
-export * from "./unique";
 export * from "./select";
+export * from "./unique";
+export * from "./virtualRef";

--- a/packages/mongoose/src/decorators/model.ts
+++ b/packages/mongoose/src/decorators/model.ts
@@ -4,7 +4,7 @@ import {createModel, createSchema} from "../utils";
 import {applySchemaOptions} from "../utils/schemaOptions";
 
 /**
- * Define a class a Mongoose Model. The model can be injected to the Service, Controller, Middleware, Converters or Filter with
+ * Define a class as a Mongoose Model. The model can be injected to the Service, Controller, Middleware, Converters or Filter with
  * `@Inject` annotation.
  *
  * ### Example

--- a/packages/mongoose/src/decorators/model.ts
+++ b/packages/mongoose/src/decorators/model.ts
@@ -1,7 +1,6 @@
 import {MongooseModelOptions} from "../interfaces/MongooseModelOptions";
 import {registerModel} from "../registries/MongooseModelRegistry";
 import {createModel, createSchema} from "../utils";
-import {applySchemaOptions} from "../utils/schemaOptions";
 
 /**
  * Define a class as a Mongoose Model. The model can be injected to the Service, Controller, Middleware, Converters or Filter with
@@ -41,10 +40,7 @@ import {applySchemaOptions} from "../utils/schemaOptions";
  */
 export function Model(options: MongooseModelOptions = {}) {
   return (target: any) => {
-    const schema = createSchema(target, options.schemaOptions);
-
-    applySchemaOptions(target, options);
-
+    const schema = createSchema(target, options);
     registerModel(target, createModel(target, schema, options.name, options.collection, options.skipInit));
   };
 }

--- a/packages/mongoose/src/decorators/postHook.ts
+++ b/packages/mongoose/src/decorators/postHook.ts
@@ -1,11 +1,10 @@
 import {getDecoratorType} from "@tsed/core";
-import {MongoosePostErrorHookCB, MongoosePostHookCB} from "../interfaces/MongooseModelOptions";
+import {MongoosePostErrorHookCB, MongoosePostHookCB} from "../interfaces";
 import {applySchemaOptions} from "../utils/schemaOptions";
 
 /**
  * We can simply attach a `@PostHook` decorator to your model class and
  * define the hook function like you normally would in Mongoose.
- *
  * ```typescript
  * import {IgnoreProperty, Required} from "@tsed/common";
  * import {PostHook, Model} from "@tsed/mongoose";

--- a/packages/mongoose/src/decorators/preHook.ts
+++ b/packages/mongoose/src/decorators/preHook.ts
@@ -1,6 +1,6 @@
 import {getDecoratorType} from "@tsed/core";
 import {HookErrorCallback} from "mongoose";
-import {MongoosePreHookAsyncCB, MongoosePreHookSyncCB} from "../interfaces/MongooseModelOptions";
+import {MongoosePreHookAsyncCB, MongoosePreHookSyncCB} from "../interfaces";
 import {applySchemaOptions} from "../utils/schemaOptions";
 
 export interface PreHookOptions {

--- a/packages/mongoose/src/decorators/schema.ts
+++ b/packages/mongoose/src/decorators/schema.ts
@@ -1,17 +1,53 @@
+import {getDecoratorType} from "@tsed/core";
 import {PropertyMetadata, PropertyRegistry} from "@tsed/common";
 import {SchemaTypeOpts} from "mongoose";
 import {MONGOOSE_SCHEMA} from "../constants";
+import {MongooseSchemaOptions} from "../interfaces";
+import {createSchema} from "../utils";
 
+/**
+ * Define a class as a Mongoose Schema ready to be used to compose other schemes and models.
+ *
+ * ### Example
+ *
+ * ```typescript
+ * @Schema()
+ * export class EventSchema {
+ *   @Property()
+ *   field: string;
+ * }
+ * ```
+ *
+ * ### Options
+ *
+ * - `schemaOptions` (mongoose.SchemaOptions): Option to configure the schema behavior.
+ *
+ * @param {MongooseSchemaOptions | undefined} options
+ * @returns {(target: any) => void}
+ * @decorator
+ * @mongoose
+ */
+export function Schema(options?: MongooseSchemaOptions): (target: any) => void;
 /**
  * Attach a schema on property class.
  *
- * @param definition A mongoose schema
+ * @param {SchemaTypeOpts<any>} definition
  * @returns {Function}
  * @decorator
  * @mongoose
  */
-export function Schema(definition: SchemaTypeOpts<any>) {
-  return PropertyRegistry.decorate((propertyMetadata: PropertyMetadata) => {
-    propertyMetadata.store.merge(MONGOOSE_SCHEMA, definition);
-  });
+export function Schema(definition: SchemaTypeOpts<any>): Function;
+export function Schema(options: MongooseSchemaOptions | SchemaTypeOpts<any> = {}) {
+  return (...parameters: any[]) => {
+    switch (getDecoratorType(parameters)) {
+      case "property":
+        return PropertyRegistry.decorate((propertyMetadata: PropertyMetadata) => {
+          propertyMetadata.store.merge(MONGOOSE_SCHEMA, options as SchemaTypeOpts<any>);
+        })(...parameters);
+      case "class":
+        const [target] = parameters;
+        createSchema(target, options as MongooseSchemaOptions);
+        break;
+    }
+  };
 }

--- a/packages/mongoose/src/decorators/virtualRef.ts
+++ b/packages/mongoose/src/decorators/virtualRef.ts
@@ -1,0 +1,49 @@
+import {PropertyMetadata, PropertyRegistry} from "@tsed/common";
+import {MONGOOSE_SCHEMA} from "../constants";
+
+export type VirtualRef<T> = T | null;
+export type VirtualRefs<T> = T[];
+
+/**
+ * Define a property as mongoose virtual reference to other Model (decorated with @Model).
+ *
+ * Warning: To avoid circular dependencies, do not use the virtual reference model in
+ * anything except a type declaration. Using the virtual reference model will prevent
+ * typescript transpiler from stripping away the import statement and cause a circular
+ * import in node.
+ *
+ * ### Example
+ *
+ * ```typescript
+ *
+ * @Model()
+ * class FooModel {
+ *
+ *    @VirtualRef("Foo2Model", "foo")
+ *    field: VirtualRef<Foo2Model>
+ *
+ *    @VirtualRef("Foo2Model", "foo")
+ *    list: VirtualRefs<Foo2Model>
+ * }
+ *
+ * @Model()
+ * class Foo2Model {
+ *    @Ref(FooModel)
+ *    foo: Ref<FooModel>;
+ * }
+ * ```
+ *
+ * @param type
+ * @returns {Function}
+ * @decorator
+ * @mongoose
+ */
+export function VirtualRef(type: string, foreignField: string) {
+  return PropertyRegistry.decorate((propertyMetadata: PropertyMetadata) => {
+    propertyMetadata.store.merge(MONGOOSE_SCHEMA, {
+      ref: type,
+      localField: propertyMetadata.name,
+      foreignField
+    });
+  });
+}

--- a/packages/mongoose/src/interfaces/MongooseModelOptions.ts
+++ b/packages/mongoose/src/interfaces/MongooseModelOptions.ts
@@ -1,75 +1,7 @@
-import {HookDoneFunction, HookErrorCallback, HookNextFunction, NativeError, Schema, SchemaOptions} from "mongoose";
-import {MongooseDocument} from "./MongooseDocument";
+import {MongooseSchemaOptions} from "./MongooseSchemaOptions";
 
-/**
- *
- */
-export interface MongoosePreHookAsyncCB<T> {
-  (doc: MongooseDocument<T>, next: HookNextFunction, done: HookDoneFunction): any;
-}
-
-export interface MongoosePreHookSyncCB<T> {
-  (doc: MongooseDocument<T>, next: HookNextFunction): any;
-}
-
-/**
- *
- */
-export interface MongoosePostErrorHookCB<T> {
-  (error: any, doc: MongooseDocument<T>, next: (err?: NativeError) => void): void;
-}
-
-/**
- *
- */
-export interface MongoosePostHookCB<T> {
-  (doc: MongooseDocument<T>, next: (err?: NativeError) => void): void;
-}
-
-/**
- *
- */
-export interface MongoosePreHook {
-  method: string;
-  fn: MongoosePreHookSyncCB<any> | MongoosePreHookAsyncCB<any>;
-  parallel?: boolean;
-  errorCb?: HookErrorCallback;
-}
-
-/**
- *
- */
-export interface MongoosePostHook {
-  method: string;
-  fn: MongoosePostHookCB<any> | MongoosePostErrorHookCB<any>;
-}
-
-/**
- *
- */
-export interface MongoosePluginOptions {
-  plugin: (schema: Schema, options?: any) => void;
-  options?: any;
-}
-
-/**
- *
- */
-export interface MongooseIndexOptions {
-  fields: object;
-  options?: any;
-}
-
-/**
- *
- */
-export interface MongooseModelOptions {
-  schemaOptions?: SchemaOptions;
+export interface MongooseModelOptions extends MongooseSchemaOptions {
   name?: string;
   collection?: string;
   skipInit?: boolean;
-  plugins?: MongoosePluginOptions[];
-  indexes?: MongooseIndexOptions[];
-  pre?: MongoosePreHook[];
-  post?: MongoosePostHook[];
 }

--- a/packages/mongoose/src/interfaces/MongooseSchema.ts
+++ b/packages/mongoose/src/interfaces/MongooseSchema.ts
@@ -1,0 +1,6 @@
+import {SchemaDefinition} from "mongoose";
+
+export interface MongooseSchema {
+  schema: SchemaDefinition;
+  virtuals: Map<string, any>;
+}

--- a/packages/mongoose/src/interfaces/MongooseSchemaOptions.ts
+++ b/packages/mongoose/src/interfaces/MongooseSchemaOptions.ts
@@ -1,0 +1,48 @@
+import {HookDoneFunction, HookErrorCallback, HookNextFunction, NativeError, Schema, SchemaOptions} from "mongoose";
+import {MongooseDocument} from "./MongooseDocument";
+
+export interface MongoosePreHookAsyncCB<T> {
+  (doc: MongooseDocument<T>, next: HookNextFunction, done: HookDoneFunction): any;
+}
+
+export interface MongoosePreHookSyncCB<T> {
+  (doc: MongooseDocument<T>, next: HookNextFunction): any;
+}
+
+export interface MongoosePostErrorHookCB<T> {
+  (error: any, doc: MongooseDocument<T>, next: (err?: NativeError) => void): void;
+}
+
+export interface MongoosePostHookCB<T> {
+  (doc: MongooseDocument<T>, next: (err?: NativeError) => void): void;
+}
+
+export interface MongoosePreHook {
+  method: string;
+  fn: MongoosePreHookSyncCB<any> | MongoosePreHookAsyncCB<any>;
+  parallel?: boolean;
+  errorCb?: HookErrorCallback;
+}
+
+export interface MongoosePostHook {
+  method: string;
+  fn: MongoosePostHookCB<any> | MongoosePostErrorHookCB<any>;
+}
+
+export interface MongoosePluginOptions {
+  plugin: (schema: Schema, options?: any) => void;
+  options?: any;
+}
+
+export interface MongooseIndexOptions {
+  fields: object;
+  options?: any;
+}
+
+export interface MongooseSchemaOptions {
+  schemaOptions?: SchemaOptions;
+  plugins?: MongoosePluginOptions[];
+  indexes?: MongooseIndexOptions[];
+  pre?: MongoosePreHook[];
+  post?: MongoosePostHook[];
+}

--- a/packages/mongoose/src/interfaces/index.ts
+++ b/packages/mongoose/src/interfaces/index.ts
@@ -2,3 +2,5 @@ export * from "./MDBConnection";
 export * from "./MongooseDocument";
 export * from "./MongooseModel";
 export * from "./MongooseModelOptions";
+export * from "./MongooseSchema";
+export * from "./MongooseSchemaOptions";

--- a/packages/mongoose/src/utils/buildMongooseSchema.ts
+++ b/packages/mongoose/src/utils/buildMongooseSchema.ts
@@ -56,6 +56,7 @@ export function buildMongooseSchema(target: any): MongooseSchema {
       const mongooseSchema = metadata.store.get(MONGOOSE_SCHEMA) || {};
 
       if (mongooseSchema.ref && mongooseSchema.localField && mongooseSchema.foreignField) {
+        mongooseSchema.justOnce = !metadata.isArray;
         schema.virtuals.set(key as string, mongooseSchema);
         continue;
       }

--- a/packages/mongoose/src/utils/buildMongooseSchema.ts
+++ b/packages/mongoose/src/utils/buildMongooseSchema.ts
@@ -1,5 +1,6 @@
-import {JsonSchemesRegistry, PropertyMetadata, PropertyRegistry} from "@tsed/common";
-import * as mongoose from "mongoose";
+import {Store} from "@tsed/core";
+import {JsonSchemesRegistry, PropertyRegistry} from "@tsed/common";
+import {MongooseSchema} from "../interfaces/MongooseSchema";
 import {MONGOOSE_SCHEMA} from "../constants";
 
 const MONGOOSE_RESERVED_KEYS = ["_id"];
@@ -37,38 +38,64 @@ export function mapProps(jsonProps: any = {}) {
 /**
  *
  * @param target
- * @returns {"mongoose".SchemaDefinition}
+ * @returns {MongooseSchema}
  */
-export function buildMongooseSchema(target: any): mongoose.SchemaDefinition {
+export function buildMongooseSchema(target: any): MongooseSchema {
   const properties = PropertyRegistry.getProperties(target);
-  const jsonSchema: any = JsonSchemesRegistry.getSchemaDefinition(target) || {};
-  const mSchema: mongoose.SchemaDefinition = {};
+  const schema: MongooseSchema = {schema: {}, virtuals: new Map()};
 
   if (properties) {
-    properties.forEach((propertyMetadata: PropertyMetadata, propertyKey: string) => {
-      if (MONGOOSE_RESERVED_KEYS.indexOf(propertyKey) > -1) {
-        return;
+    const jsonSchema: any = JsonSchemesRegistry.getSchemaDefinition(target) || {properties: {}};
+
+    for (const [key, metadata] of properties.entries()) {
+      if (MONGOOSE_RESERVED_KEYS.includes(key as string)) {
+        continue;
       }
 
-      let definition = {
-        required: propertyMetadata.required
-          ? function() {
-              return propertyMetadata.isRequired(this[propertyKey]);
-            }
-          : false
+      // Keeping the Mongoose Schema separate so it can overwrite everything once schema has been built.
+      const mongooseSchema = metadata.store.get(MONGOOSE_SCHEMA) || {};
+
+      if (mongooseSchema.ref && mongooseSchema.localField && mongooseSchema.foreignField) {
+        schema.virtuals.set(key as string, mongooseSchema);
+        continue;
+      }
+
+      let definition: any = {
+        required: metadata.required ? () => metadata.isRequired(this[key]) : false
       };
 
-      if (propertyMetadata.isClass) {
-        definition = Object.assign(definition, buildMongooseSchema(propertyMetadata.type));
-      } else {
-        definition = Object.assign(definition, {type: propertyMetadata.type}, mapProps((jsonSchema.properties || {})[propertyKey]));
+      if (!metadata.isClass) {
+        definition = Object.assign(definition, {type: metadata.type}, mapProps(jsonSchema.properties[key]));
+      } else if (!mongooseSchema.ref) {
+        // References are handled by the final merge
+        const propSchema = Store.from(metadata.type).get(MONGOOSE_SCHEMA);
+
+        if (!propSchema) {
+          throw new Error(`${metadata.typeName} is not a registered subdocument. Use decorator '@Subdocument' on the class.`);
+        }
+
+        definition = Object.assign(definition, {type: propSchema});
       }
 
-      definition = clean(Object.assign(definition, propertyMetadata.store.get(MONGOOSE_SCHEMA) || {}));
+      definition = clean(Object.assign(definition, mongooseSchema));
 
-      mSchema[propertyKey] = propertyMetadata.isArray ? [definition] : definition;
-    });
+      if (metadata.isCollection) {
+        if (metadata.isArray) {
+          definition = [definition];
+        } else {
+          // Can be a Map or a Set;
+          // Mongoose implements only Map;
+          if (metadata.collectionType !== Map) {
+            throw new Error(`Invalid collection type. ${metadata.collectionName} is not supported.`);
+          }
+
+          definition = {type: Map, of: definition};
+        }
+      }
+
+      schema.schema[key as string] = definition;
+    }
   }
 
-  return mSchema;
+  return schema;
 }

--- a/packages/mongoose/src/utils/buildMongooseSchema.ts
+++ b/packages/mongoose/src/utils/buildMongooseSchema.ts
@@ -1,7 +1,7 @@
 import {Store} from "@tsed/core";
 import {JsonSchemesRegistry, PropertyRegistry} from "@tsed/common";
-import {MongooseSchema} from "../interfaces/MongooseSchema";
 import {MONGOOSE_SCHEMA} from "../constants";
+import {MongooseSchema} from "../interfaces";
 
 const MONGOOSE_RESERVED_KEYS = ["_id"];
 

--- a/packages/mongoose/src/utils/buildMongooseSchema.ts
+++ b/packages/mongoose/src/utils/buildMongooseSchema.ts
@@ -56,13 +56,21 @@ export function buildMongooseSchema(target: any): MongooseSchema {
       const mongooseSchema = metadata.store.get(MONGOOSE_SCHEMA) || {};
 
       if (mongooseSchema.ref && mongooseSchema.localField && mongooseSchema.foreignField) {
+        if (metadata.required) {
+          throw new Error("Virtual references cannot be required.");
+        }
+
         mongooseSchema.justOnce = !metadata.isArray;
         schema.virtuals.set(key as string, mongooseSchema);
         continue;
       }
 
       let definition: any = {
-        required: metadata.required ? () => metadata.isRequired(this[key]) : false
+        required: metadata.required
+          ? function() {
+              return metadata.isRequired(this[key]);
+            }
+          : false
       };
 
       if (!metadata.isClass) {

--- a/packages/mongoose/src/utils/createModel.ts
+++ b/packages/mongoose/src/utils/createModel.ts
@@ -22,18 +22,6 @@ export function createModel<T>(
   skipInit?: boolean
 ): MongooseModel<T> {
   Store.from(target).set(MONGOOSE_MODEL_NAME, name);
-  target.prototype.serialize = function(options: IConverterOptions, converterService: ConverterService) {
-    const {checkRequiredValue, ignoreCallback} = options;
 
-    return converterService.serializeClass(this, {
-      type: getClass(target),
-      checkRequiredValue,
-      ignoreCallback
-    });
-  };
-
-  schema.loadClass(target);
-  const modelInstance: any = mongoose.model(name, schema, collection, skipInit);
-
-  return modelInstance;
+  return mongoose.model(name, schema, collection, skipInit);
 }

--- a/packages/mongoose/src/utils/createSchema.ts
+++ b/packages/mongoose/src/utils/createSchema.ts
@@ -1,7 +1,32 @@
-import {Store, Type} from "@tsed/core";
+import {getClass, Store, Type} from "@tsed/core";
+import {ConverterService, IConverterOptions} from "@tsed/common";
 import * as mongoose from "mongoose";
 import {MONGOOSE_SCHEMA} from "../constants";
 import {buildMongooseSchema} from "./buildMongooseSchema";
+import {MongooseSchema} from "../interfaces/MongooseSchema";
+
+function setUpTarget(target: Type<any>) {
+  // Using function to avoid this binding.
+  target.prototype.serialize = function(options: IConverterOptions, converter: ConverterService) {
+    const {checkRequiredValue, ignoreCallback} = options;
+
+    return converter.serializeClass(this, {
+      type: getClass(target),
+      checkRequiredValue,
+      ignoreCallback
+    });
+  };
+}
+
+function setUpSchema({schema, virtuals}: MongooseSchema, options?: mongoose.SchemaOptions) {
+  const mongooseSchema = new mongoose.Schema(schema, options);
+
+  for (const [key, options] of virtuals.entries()) {
+    mongooseSchema.virtual(key, options);
+  }
+
+  return mongooseSchema;
+}
 
 /**
  *
@@ -13,8 +38,11 @@ export function createSchema(target: Type<any>, options?: mongoose.SchemaOptions
   const store = Store.from(target);
 
   if (!store.has(MONGOOSE_SCHEMA)) {
-    const definition: mongoose.SchemaDefinition = buildMongooseSchema(target);
-    store.set(MONGOOSE_SCHEMA, new mongoose.Schema(definition, options));
+    const schema = setUpSchema(buildMongooseSchema(target), options);
+
+    setUpTarget(target);
+    schema.loadClass(target);
+    store.set(MONGOOSE_SCHEMA, schema);
   }
 
   return store.get(MONGOOSE_SCHEMA);

--- a/packages/mongoose/src/utils/createSchema.ts
+++ b/packages/mongoose/src/utils/createSchema.ts
@@ -2,11 +2,11 @@ import {getClass, Store, Type} from "@tsed/core";
 import {ConverterService, IConverterOptions} from "@tsed/common";
 import * as mongoose from "mongoose";
 import {MONGOOSE_SCHEMA} from "../constants";
+import {MongooseSchema, MongooseSchemaOptions} from "../interfaces";
 import {buildMongooseSchema} from "./buildMongooseSchema";
-import {MongooseSchema} from "../interfaces/MongooseSchema";
+import {applySchemaOptions} from "./schemaOptions";
 
 function setUpTarget(target: Type<any>) {
-  // Using function to avoid this binding.
   target.prototype.serialize = function(options: IConverterOptions, converter: ConverterService) {
     const {checkRequiredValue, ignoreCallback} = options;
 
@@ -34,15 +34,15 @@ function setUpSchema({schema, virtuals}: MongooseSchema, options?: mongoose.Sche
  * @param {"mongoose".SchemaOptions} options
  * @returns {"mongoose".Schema}
  */
-export function createSchema(target: Type<any>, options?: mongoose.SchemaOptions): mongoose.Schema {
+export function createSchema(target: Type<any>, options: MongooseSchemaOptions = {}): mongoose.Schema {
   const store = Store.from(target);
 
   if (!store.has(MONGOOSE_SCHEMA)) {
-    const schema = setUpSchema(buildMongooseSchema(target), options);
-
+    const schema = setUpSchema(buildMongooseSchema(target), options.schemaOptions);
+    store.set(MONGOOSE_SCHEMA, schema);
+    applySchemaOptions(target, options);
     setUpTarget(target);
     schema.loadClass(target);
-    store.set(MONGOOSE_SCHEMA, schema);
   }
 
   return store.get(MONGOOSE_SCHEMA);

--- a/packages/mongoose/src/utils/schemaOptions.ts
+++ b/packages/mongoose/src/utils/schemaOptions.ts
@@ -1,19 +1,18 @@
 import {deepExtends, Store} from "@tsed/core";
 import {HookDoneFunction, HookNextFunction, Schema} from "mongoose";
 import {MONGOOSE_SCHEMA, MONGOOSE_SCHEMA_OPTIONS} from "../constants";
-import {MongooseModelOptions} from "../interfaces/MongooseModelOptions";
+import {MongooseSchemaOptions} from "../interfaces";
 
 /**
  *
  * @param target
- * @param {MongooseModelOptions} options
+ * @param {MongooseSchemaOptions} options
  */
-export function schemaOptions(target: any, options?: MongooseModelOptions) {
+export function schemaOptions(target: any, options?: MongooseSchemaOptions) {
   const store = Store.from(target);
-  if (options) {
-    options = deepExtends(store.get(MONGOOSE_SCHEMA_OPTIONS) || {}, options);
-    store.set(MONGOOSE_SCHEMA_OPTIONS, options);
-  }
+
+  options = deepExtends(store.get(MONGOOSE_SCHEMA_OPTIONS) || {}, options);
+  store.set(MONGOOSE_SCHEMA_OPTIONS, options);
 
   return store.get(MONGOOSE_SCHEMA_OPTIONS);
 }
@@ -24,23 +23,21 @@ export function schemaOptions(target: any, options?: MongooseModelOptions) {
  * @returns {any}
  */
 export function buildPreHook(fn: Function) {
-  if (fn.length === 2) {
-    return function(next: HookNextFunction) {
-      return fn(this, next);
-    };
-  }
-
-  return function(next: HookNextFunction, done: HookDoneFunction) {
-    return fn(this, next, done);
-  };
+  return fn.length === 2
+    ? function(next: HookNextFunction) {
+        return fn(this, next);
+      }
+    : function(next: HookNextFunction, done: HookDoneFunction) {
+        return fn(this, next, done);
+      };
 }
 
 /**
  *
  * @param target
- * @param {MongooseModelOptions} options
+ * @param {MongooseSchemaOptions} options
  */
-export function applySchemaOptions(target: any, options: MongooseModelOptions) {
+export function applySchemaOptions(target: any, options: MongooseSchemaOptions) {
   const store = Store.from(target);
 
   options = schemaOptions(target, options);
@@ -49,9 +46,7 @@ export function applySchemaOptions(target: any, options: MongooseModelOptions) {
     const schema: Schema = store.get(MONGOOSE_SCHEMA);
 
     if (options.plugins) {
-      if (options.plugins) {
-        options.plugins.forEach(item => schema.plugin(item.plugin, item.options));
-      }
+      options.plugins.forEach(item => schema.plugin(item.plugin, item.options));
     }
 
     if (options.indexes) {

--- a/packages/mongoose/test/decorators/model.spec.ts
+++ b/packages/mongoose/test/decorators/model.spec.ts
@@ -1,7 +1,6 @@
 import {Model} from "../../src/decorators";
 import * as register from "../../src/registries/MongooseModelRegistry";
 import * as modUtil from "../../src/utils";
-import * as apply from "../../src/utils/schemaOptions";
 import * as Sinon from "sinon";
 
 describe("@Model()", () => {
@@ -10,7 +9,6 @@ describe("@Model()", () => {
 
     before(() => {
       this.createSchemaStub = Sinon.stub(modUtil, "createSchema").returns({schema: "schema"} as any);
-      this.applySchemaOptionStub = Sinon.stub(apply, "applySchemaOptions");
       this.createModelStub = Sinon.stub(modUtil, "createModel").returns({model: "model"} as any);
       this.registerModelStub = Sinon.stub(register, "registerModel");
 
@@ -23,17 +21,12 @@ describe("@Model()", () => {
     });
     after(() => {
       this.createSchemaStub.restore();
-      this.applySchemaOptionStub.restore();
       this.registerModelStub.restore();
       this.createModelStub.restore();
     });
 
     it("should call createSchema", () => {
-      this.createSchemaStub.should.have.been.calledWithExactly(Test, "schemaOptions");
-    });
-
-    it("should call createSchema", () => {
-      this.applySchemaOptionStub.should.have.been.calledWithExactly(Test, {
+      this.createSchemaStub.should.have.been.calledWithExactly(Test, {
         schemaOptions: "schemaOptions",
         name: "name",
         collection: "collection",
@@ -55,7 +48,6 @@ describe("@Model()", () => {
 
     before(() => {
       this.createSchemaStub = Sinon.stub(modUtil, "createSchema").returns({schema: "schema"} as any);
-      this.applySchemaOptionStub = Sinon.stub(apply, "applySchemaOptions");
       this.createModelStub = Sinon.stub(modUtil, "createModel").returns({model: "model"} as any);
       this.registerModelStub = Sinon.stub(register, "registerModel");
 
@@ -63,17 +55,12 @@ describe("@Model()", () => {
     });
     after(() => {
       this.createSchemaStub.restore();
-      this.applySchemaOptionStub.restore();
       this.registerModelStub.restore();
       this.createModelStub.restore();
     });
 
     it("should call createSchema", () => {
-      this.createSchemaStub.should.have.been.calledWithExactly(Test, undefined);
-    });
-
-    it("should call applySchemaOption", () => {
-      this.applySchemaOptionStub.should.have.been.calledWithExactly(Test, {});
+      this.createSchemaStub.should.have.been.calledWithExactly(Test, {});
     });
 
     it("should call createModelStub", () => {

--- a/packages/mongoose/test/decorators/schema.spec.ts
+++ b/packages/mongoose/test/decorators/schema.spec.ts
@@ -1,0 +1,51 @@
+import {Schema} from "../../src/decorators";
+import * as modUtil from "../../src/utils";
+import * as Sinon from "sinon";
+
+describe("@Model()", () => {
+  describe("when decorator type is class", () => {
+    describe("with options", () => {
+      class Test {}
+
+      before(() => {
+        this.createSchemaStub = Sinon.stub(modUtil, "createSchema").returns({schema: "schema"} as any);
+
+        Schema({
+          schemaOptions: "schemaOptions",
+        } as any)(Test);
+      });
+
+      after(() => {
+        this.createSchemaStub.restore();
+      });
+
+      it("should call createSchema", () => {
+        this.createSchemaStub.should.have.been.calledWithExactly(Test, {
+          schemaOptions: "schemaOptions",
+        });
+      });
+    });
+
+    describe("without options", () => {
+      class Test {}
+
+      before(() => {
+        this.createSchemaStub = Sinon.stub(modUtil, "createSchema").returns({schema: "schema"} as any);
+
+        Schema()(Test);
+      });
+
+      after(() => {
+        this.createSchemaStub.restore();
+      });
+
+      it("should call createSchema", () => {
+        this.createSchemaStub.should.have.been.calledWithExactly(Test, {});
+      });
+    });
+  });
+
+  describe("when decorator type is property", () => {
+    // There were no test previously...
+  });
+});

--- a/packages/mongoose/test/decorators/virtualRef.spec.ts
+++ b/packages/mongoose/test/decorators/virtualRef.spec.ts
@@ -1,0 +1,23 @@
+import {Store} from "@tsed/core";
+import {descriptorOf} from "@tsed/core";
+import {MONGOOSE_SCHEMA} from "../../src/constants";
+import {VirtualRef} from "../../src/decorators";
+import {expect} from "chai";
+
+describe("@VirtualRef()", () => {
+  class Test {}
+  class RefTest {}
+
+  before(() => {
+    VirtualRef("RefTest", "foreign")(Test, "test", descriptorOf(Test, "test"));
+    this.store = Store.from(Test, "test", descriptorOf(Test, "test"));
+  });
+
+  it("should set metadata", () => {
+    expect(this.store.get(MONGOOSE_SCHEMA)).to.deep.eq({
+      ref: "RefTest",
+      foreignField: "foreign",
+      localField: "test"
+    });
+  });
+});

--- a/packages/mongoose/test/mongoose.spec.ts
+++ b/packages/mongoose/test/mongoose.spec.ts
@@ -1,5 +1,5 @@
 import {Allow, ConverterService, Property, PropertyType, Required} from "@tsed/common";
-import {Model, MongooseModel} from "@tsed/mongoose";
+import {Model, MongooseModel, Schema} from "@tsed/mongoose";
 import {inject, TestContext} from "@tsed/testing";
 import {expect} from "chai";
 
@@ -12,6 +12,7 @@ export class TestModel {
   @Property() number: number;
 }
 
+@Schema()
 export class AdminModel {
   @Property({name: "id"}) // this one looks like _id in response, but it should be just id
   _id: string;

--- a/packages/mongoose/test/utils/buildMongooseSchema.spec.ts
+++ b/packages/mongoose/test/utils/buildMongooseSchema.spec.ts
@@ -61,7 +61,6 @@ describe("buildMongooseSchema", () => {
       after(() => {
         this.getPropertiesStub.restore();
         this.getSchemaDefinitionStub.restore();
-        this.propertyMetadata.store.get.restore();
       });
 
       it("should call getProperties and returns a list of properties", () => {
@@ -124,7 +123,6 @@ describe("buildMongooseSchema", () => {
       after(() => {
         this.getPropertiesStub.restore();
         this.getSchemaDefinitionStub.restore();
-        this.propertyMetadata.store.get.restore();
       });
 
       it("should call getProperties and returns a list of properties", () => {
@@ -189,7 +187,6 @@ describe("buildMongooseSchema", () => {
       after(() => {
         this.getPropertiesStub.restore();
         this.getSchemaDefinitionStub.restore();
-        this.propertyMetadata.store.get.restore();
       });
 
       it("should call getProperties and returns a list of properties", () => {
@@ -270,8 +267,6 @@ describe("buildMongooseSchema", () => {
         after(() => {
           this.getPropertiesStub.restore();
           this.getSchemaDefinitionStub.restore();
-          this.propertyMetadata.store.get.restore();
-          this.innerPropertyMetadata.store.get.restore();
         });
 
         it("should call getProperties and returns a list of properties", () => {
@@ -349,8 +344,6 @@ describe("buildMongooseSchema", () => {
         after(() => {
           this.getPropertiesStub.restore();
           this.getSchemaDefinitionStub.restore();
-          this.propertyMetadata.store.get.restore();
-          this.innerPropertyMetadata.store.get.restore();
         });
 
         it("should call getProperties and returns a list of properties", () => {
@@ -440,9 +433,6 @@ describe("buildMongooseSchema", () => {
         after(() => {
           this.getPropertiesStub.restore();
           this.getSchemaDefinitionStub.restore();
-          this.propertyMetadata.store.get.restore();
-          this.reversePropertyMetadata.store.get.restore();
-          this.innerPropertyMetadata.store.get.restore();
         });
 
         it("should call getProperties and returns a list of properties", () => {

--- a/packages/mongoose/test/utils/buildMongooseSchema.spec.ts
+++ b/packages/mongoose/test/utils/buildMongooseSchema.spec.ts
@@ -1,9 +1,10 @@
-import { JsonSchemesRegistry, PropertyRegistry } from "@tsed/common";
-import { Schema } from "mongoose";
-import { expect } from "chai";
+import {Store} from "@tsed/core";
+import {JsonSchemesRegistry, PropertyRegistry} from "@tsed/common";
+import {Schema} from "mongoose";
+import {expect} from "chai";
 import * as Sinon from "sinon";
-import { MONGOOSE_SCHEMA } from "../../src/constants";
-import { buildMongooseSchema, mapProps } from "../../src/utils/buildMongooseSchema";
+import {MONGOOSE_SCHEMA} from "../../src/constants";
+import {buildMongooseSchema, mapProps} from "../../src/utils/buildMongooseSchema";
 
 describe("buildMongooseSchema", () => {
   describe("mapProps()", () => {
@@ -31,16 +32,16 @@ describe("buildMongooseSchema", () => {
   });
 
   describe("buildMongooseSchema()", () => {
-    class Test { }
+    class Test {}
 
-    describe("when property is not a class", () => {
+    describe("when property is a primitive", () => {
       before(() => {
         this.propertyMetadata = {
           type: String,
           required: true,
           isClass: false,
           store: {
-            get: Sinon.stub().returns({ minLength: 1 })
+            get: Sinon.stub().returns({minLength: 1})
           }
         };
 
@@ -72,26 +73,30 @@ describe("buildMongooseSchema", () => {
       });
 
       it("should return a schema with property test", () => {
-        expect(this.result)
+        expect(this.result.schema)
           .to.haveOwnProperty("test")
           .that.is.an("object");
-        expect(this.result.test)
+        expect(this.result.schema.test)
           .to.haveOwnProperty("maxlength")
           .that.equals(9);
-        expect(this.result.test)
+        expect(this.result.schema.test)
           .to.haveOwnProperty("minLength")
           .that.equals(1);
-        expect(this.result.test)
+        expect(this.result.schema.test)
           .to.haveOwnProperty("required")
           .that.is.a("function");
-        expect(this.result.test)
+        expect(this.result.schema.test)
           .to.haveOwnProperty("type")
           .that.equals(String);
       });
 
       it("should not have an _id", () => {
-        expect(this.result).to.not.haveOwnProperty("_id");
+        expect(this.result.schema).to.not.haveOwnProperty("_id");
       });
+
+      it("should have no virtuals", () => {
+        expect(this.result.virtuals).to.be.empty;
+      })
     });
 
     describe("when property is an array", () => {
@@ -100,9 +105,10 @@ describe("buildMongooseSchema", () => {
           type: String,
           required: true,
           isArray: true,
+          isCollection: true,
           isClass: false,
           store: {
-            get: Sinon.stub().returns({ minLength: 1 })
+            get: Sinon.stub().returns({minLength: 1})
           }
         };
 
@@ -134,27 +140,31 @@ describe("buildMongooseSchema", () => {
       });
 
       it("should return a schema with property test", () => {
-        expect(this.result)
+        expect(this.result.schema)
           .to.haveOwnProperty("test")
           .that.is.an("array")
           .that.have.lengthOf(1);
-        expect(this.result.test[0])
+        expect(this.result.schema.test[0])
           .to.haveOwnProperty("maxlength")
           .that.equals(9);
-        expect(this.result.test[0])
+        expect(this.result.schema.test[0])
           .to.haveOwnProperty("minLength")
           .that.equals(1);
-        expect(this.result.test[0])
+        expect(this.result.schema.test[0])
           .to.haveOwnProperty("required")
           .that.is.a("function");
-        expect(this.result.test[0])
+        expect(this.result.schema.test[0])
           .to.haveOwnProperty("type")
           .that.equals(String);
       });
 
       it("should not have an _id", () => {
-        expect(this.result).to.not.haveOwnProperty("_id");
+        expect(this.result.schema).to.not.haveOwnProperty("_id");
       });
+
+      it("should have no virtuals", () => {
+        expect(this.result.virtuals).to.be.empty;
+      })
     });
 
     describe("when property is a map", () => {
@@ -165,8 +175,9 @@ describe("buildMongooseSchema", () => {
           isClass: false,
           isArray: false,
           isCollection: true,
+          collectionType: Map,
           store: {
-            get: Sinon.stub().returns({ minLength: 1 })
+            get: Sinon.stub().returns({minLength: 1})
           }
         };
 
@@ -198,33 +209,39 @@ describe("buildMongooseSchema", () => {
       });
 
       it("should return a schema with property test", () => {
-        expect(this.result)
+        expect(this.result.schema)
           .to.haveOwnProperty("test")
           .that.is.an("object");
-        expect(this.result.test)
-          .to.haveOwnProperty("maxlength")
-          .that.equals(9);
-        expect(this.result.test)
-          .to.haveOwnProperty("minLength")
-          .that.equals(1);
-        expect(this.result.test)
-          .to.haveOwnProperty("required")
-          .that.is.a("function");
-        expect(this.result.test)
+        expect(this.result.schema.test)
           .to.haveOwnProperty("type")
           .that.equals(Map);
-        expect(this.result.test)
+        expect(this.result.schema.test)
           .to.haveOwnProperty("of")
+          .that.is.an("object");
+        expect(this.result.schema.test.of)
+          .to.haveOwnProperty("type")
           .that.equals(String);
+        expect(this.result.schema.test.of)
+          .to.haveOwnProperty("maxlength")
+          .that.equals(9);
+        expect(this.result.schema.test.of)
+          .to.haveOwnProperty("minLength")
+          .that.equals(1);
+        expect(this.result.schema.test.of)
+          .to.haveOwnProperty("required")
+          .that.is.a("function");
+      });
+      it("should not have an _id", () => {
+        expect(this.result.schema).to.not.haveOwnProperty("_id");
       });
 
-      it("should not have an _id", () => {
-        expect(this.result).to.not.haveOwnProperty("_id");
-      });
+      it("should have no virtuals", () => {
+        expect(this.result.virtuals).to.be.empty;
+      })
     });
 
     describe("when property is a class", () => {
-      class Children { }
+      class Children {}
 
       describe("when property is a subdocument", () => {
         before(() => {
@@ -232,16 +249,6 @@ describe("buildMongooseSchema", () => {
             type: Children,
             required: true,
             isClass: true,
-            store: {
-              get: Sinon.stub().returns(undefined)
-            }
-          };
-
-          this.innerPropertyMetadata = {
-            type: String,
-            required: false,
-            isClass: false,
-            isArray: true,
             store: {
               get: Sinon.stub().returns(undefined)
             }
@@ -261,12 +268,20 @@ describe("buildMongooseSchema", () => {
               }
             });
 
+          // @ts-ignore @types/sinon doesn't allow to use overrides with sinon.createStubInstance.
+          this.storeResultStub = Sinon.createStubInstance(Store, {
+            has: Sinon.stub().returns(true),
+            get: Sinon.stub().returns("Schema")
+          });
+
+          this.storeFromStub = Sinon.stub(Store, "from").returns(this.storeResultStub);
           this.result = buildMongooseSchema(Test);
         });
 
         after(() => {
           this.getPropertiesStub.restore();
           this.getSchemaDefinitionStub.restore();
+          this.storeFromStub.restore();
         });
 
         it("should call getProperties and returns a list of properties", () => {
@@ -279,25 +294,24 @@ describe("buildMongooseSchema", () => {
         });
 
         it("should return a schema with property test", () => {
-          expect(this.result)
+          expect(this.result.schema)
             .to.haveOwnProperty("test")
             .that.is.an("object");
-          expect(this.result.test)
+          expect(this.result.schema.test)
             .to.haveOwnProperty("required")
             .that.is.a("function");
-          expect(this.result.test)
-            .to.haveOwnProperty("prop")
-            .that.deep.equals([
-              {
-                required: false,
-                type: String
-              }
-            ]);
+          expect(this.result.schema.test)
+            .to.haveOwnProperty("type")
+            .that.equals("Schema");
         });
 
         it("should not have an _id", () => {
-          expect(this.result).to.not.haveOwnProperty("_id");
+          expect(this.result.schema).to.not.haveOwnProperty("_id");
         });
+
+        it("should have no virtuals", () => {
+          expect(this.result.virtuals).to.be.empty;
+        })
       });
 
       describe("when property is a reference class", () => {
@@ -348,6 +362,7 @@ describe("buildMongooseSchema", () => {
 
         it("should call getProperties and returns a list of properties", () => {
           this.getPropertiesStub.should.have.been.calledWithExactly(Test);
+          this.getPropertiesStub.should.not.have.been.calledWithExactly(Children);
         });
 
         it("should call store.get", () => {
@@ -355,24 +370,28 @@ describe("buildMongooseSchema", () => {
         });
 
         it("should return a schema with property test", () => {
-          expect(this.result)
+          expect(this.result.schema)
             .to.haveOwnProperty("test")
             .that.is.an("object");
-          expect(this.result.test)
+          expect(this.result.schema.test)
             .to.haveOwnProperty("type")
             .that.equals(Schema.Types.ObjectId);
-          expect(this.result.test)
+          expect(this.result.schema.test)
             .to.haveOwnProperty("ref")
             .that.equals("Children");
-          expect(this.result.test)
+          expect(this.result.schema.test)
             .to.haveOwnProperty("required")
             .that.is.a("function");
-          expect(this.result.test).to.not.haveOwnProperty("prop");
+          expect(this.result.schema.test).to.not.haveOwnProperty("prop");
         });
 
         it("should not have an _id", () => {
-          expect(this.result).to.not.haveOwnProperty("_id");
+          expect(this.result.schema).to.not.haveOwnProperty("_id");
         });
+
+        it("should have no virtuals", () => {
+          expect(this.result.virtuals).to.be.empty;
+        })
       });
 
       describe("when property is a virtual reference", () => {
@@ -443,14 +462,17 @@ describe("buildMongooseSchema", () => {
           this.propertyMetadata.store.get.should.have.been.calledWithExactly(MONGOOSE_SCHEMA);
         });
 
-        it("should return a schema with property test", () => {
-          expect(this.result).to.not.haveOwnProperty("test");
-          expect(this.result.virtuals).to.haveOwnProperty("test");
+        it("should return a schema without property test", () => {
+          expect(this.result.schema).to.not.haveOwnProperty("test");
         });
 
         it("should not have an _id", () => {
-          expect(this.result).to.not.haveOwnProperty("_id");
+          expect(this.result.schema).to.not.haveOwnProperty("_id");
         });
+
+        it("should have a test virtual", () => {
+          expect(this.result.virtuals).to.have.key("test");
+        })
       });
     });
   });

--- a/packages/mongoose/test/utils/buildMongooseSchema.spec.ts
+++ b/packages/mongoose/test/utils/buildMongooseSchema.spec.ts
@@ -1,8 +1,9 @@
-import {JsonSchemesRegistry, PropertyRegistry} from "@tsed/common";
-import {expect} from "chai";
+import { JsonSchemesRegistry, PropertyRegistry } from "@tsed/common";
+import { Schema } from "mongoose";
+import { expect } from "chai";
 import * as Sinon from "sinon";
-import {MONGOOSE_SCHEMA} from "../../src/constants";
-import {buildMongooseSchema, mapProps} from "../../src/utils/buildMongooseSchema";
+import { MONGOOSE_SCHEMA } from "../../src/constants";
+import { buildMongooseSchema, mapProps } from "../../src/utils/buildMongooseSchema";
 
 describe("buildMongooseSchema", () => {
   describe("mapProps()", () => {
@@ -30,24 +31,22 @@ describe("buildMongooseSchema", () => {
   });
 
   describe("buildMongooseSchema()", () => {
-    describe("when property is not a class", () => {
-      class Test {
-      }
+    class Test { }
 
+    describe("when property is not a class", () => {
       before(() => {
         this.propertyMetadata = {
           type: String,
           required: true,
           isClass: false,
           store: {
-            get: Sinon.stub().returns({minLength: 1})
+            get: Sinon.stub().returns({ minLength: 1 })
           }
         };
 
-        const map = new Map();
-        map.set("test", this.propertyMetadata);
-
-        this.getPropertiesStub = Sinon.stub(PropertyRegistry, "getProperties").returns(map);
+        this.getPropertiesStub = Sinon.stub(PropertyRegistry, "getProperties").returns(
+          new Map<string, any>([["test", this.propertyMetadata]])
+        );
 
         this.getSchemaDefinitionStub = Sinon.stub(JsonSchemesRegistry, "getSchemaDefinition").returns({
           properties: {
@@ -62,6 +61,7 @@ describe("buildMongooseSchema", () => {
       after(() => {
         this.getPropertiesStub.restore();
         this.getSchemaDefinitionStub.restore();
+        this.propertyMetadata.store.get.restore();
       });
 
       it("should call getProperties and returns a list of properties", () => {
@@ -72,64 +72,59 @@ describe("buildMongooseSchema", () => {
         this.propertyMetadata.store.get.should.have.been.calledWithExactly(MONGOOSE_SCHEMA);
       });
 
-      it("should return a schema", () => {
-        expect(this.result.test.maxlength).to.eq(9);
-        expect(this.result.test.minLength).to.eq(1);
-        expect(this.result.test.required).to.be.a("function");
-        expect(this.result.test.type).to.eq(String);
+      it("should return a schema with property test", () => {
+        expect(this.result)
+          .to.haveOwnProperty("test")
+          .that.is.an("object");
+        expect(this.result.test)
+          .to.haveOwnProperty("maxlength")
+          .that.equals(9);
+        expect(this.result.test)
+          .to.haveOwnProperty("minLength")
+          .that.equals(1);
+        expect(this.result.test)
+          .to.haveOwnProperty("required")
+          .that.is.a("function");
+        expect(this.result.test)
+          .to.haveOwnProperty("type")
+          .that.equals(String);
+      });
+
+      it("should not have an _id", () => {
+        expect(this.result).to.not.haveOwnProperty("_id");
       });
     });
-    describe("when property is a class", () => {
-      class Test {
-      }
 
-      class Children {
-      }
-
+    describe("when property is an array", () => {
       before(() => {
         this.propertyMetadata = {
-          type: Children,
+          type: String,
           required: true,
-          isClass: true,
+          isArray: true,
+          isClass: false,
           store: {
-            get: Sinon.stub().returns(undefined)
+            get: Sinon.stub().returns({ minLength: 1 })
           }
         };
 
-        const map = new Map();
-        map.set("test", this.propertyMetadata);
-        map.set("_id", {});
+        this.getPropertiesStub = Sinon.stub(PropertyRegistry, "getProperties").returns(
+          new Map<string, any>([["test", this.propertyMetadata]])
+        );
 
-        const map2 = new Map();
-        map2.set("test2", {
-          type: String,
-          required: false,
-          isClass: false,
-          isArray: true,
-          store: {
-            get: Sinon.stub().returns(undefined)
+        this.getSchemaDefinitionStub = Sinon.stub(JsonSchemesRegistry, "getSchemaDefinition").returns({
+          properties: {
+            test: {
+              maxLength: 9
+            }
           }
         });
-
-        this.getPropertiesStub = Sinon.stub(PropertyRegistry, "getProperties")
-          .onFirstCall()
-          .returns(map)
-          .onSecondCall()
-          .returns(map2);
-
-        this.getSchemaDefinitionStub = Sinon.stub(JsonSchemesRegistry, "getSchemaDefinition")
-          .onFirstCall()
-          .returns({
-            properties: {
-              test: {}
-            }
-          });
 
         this.result = buildMongooseSchema(Test);
       });
       after(() => {
         this.getPropertiesStub.restore();
         this.getSchemaDefinitionStub.restore();
+        this.propertyMetadata.store.get.restore();
       });
 
       it("should call getProperties and returns a list of properties", () => {
@@ -140,19 +135,332 @@ describe("buildMongooseSchema", () => {
         this.propertyMetadata.store.get.should.have.been.calledWithExactly(MONGOOSE_SCHEMA);
       });
 
-      it("should return a schema", () => {
-        expect(this.result.test.required).to.be.a("function");
-        expect(this.result.test.required).to.be.a("function");
-        expect(this.result.test.test2).deep.eq([
-          {
-            required: false,
-            type: String
-          }
-        ]);
+      it("should return a schema with property test", () => {
+        expect(this.result)
+          .to.haveOwnProperty("test")
+          .that.is.an("array")
+          .that.have.lengthOf(1);
+        expect(this.result.test[0])
+          .to.haveOwnProperty("maxlength")
+          .that.equals(9);
+        expect(this.result.test[0])
+          .to.haveOwnProperty("minLength")
+          .that.equals(1);
+        expect(this.result.test[0])
+          .to.haveOwnProperty("required")
+          .that.is.a("function");
+        expect(this.result.test[0])
+          .to.haveOwnProperty("type")
+          .that.equals(String);
       });
 
       it("should not have an _id", () => {
-        expect(this.result._id).to.eq(undefined);
+        expect(this.result).to.not.haveOwnProperty("_id");
+      });
+    });
+
+    describe("when property is a map", () => {
+      before(() => {
+        this.propertyMetadata = {
+          type: String,
+          required: true,
+          isClass: false,
+          isArray: false,
+          isCollection: true,
+          store: {
+            get: Sinon.stub().returns({ minLength: 1 })
+          }
+        };
+
+        this.getPropertiesStub = Sinon.stub(PropertyRegistry, "getProperties").returns(
+          new Map<string, any>([["test", this.propertyMetadata]])
+        );
+
+        this.getSchemaDefinitionStub = Sinon.stub(JsonSchemesRegistry, "getSchemaDefinition").returns({
+          properties: {
+            test: {
+              maxLength: 9
+            }
+          }
+        });
+
+        this.result = buildMongooseSchema(Test);
+      });
+      after(() => {
+        this.getPropertiesStub.restore();
+        this.getSchemaDefinitionStub.restore();
+        this.propertyMetadata.store.get.restore();
+      });
+
+      it("should call getProperties and returns a list of properties", () => {
+        this.getPropertiesStub.should.have.been.calledWithExactly(Test);
+      });
+
+      it("should call store.get", () => {
+        this.propertyMetadata.store.get.should.have.been.calledWithExactly(MONGOOSE_SCHEMA);
+      });
+
+      it("should return a schema with property test", () => {
+        expect(this.result)
+          .to.haveOwnProperty("test")
+          .that.is.an("object");
+        expect(this.result.test)
+          .to.haveOwnProperty("maxlength")
+          .that.equals(9);
+        expect(this.result.test)
+          .to.haveOwnProperty("minLength")
+          .that.equals(1);
+        expect(this.result.test)
+          .to.haveOwnProperty("required")
+          .that.is.a("function");
+        expect(this.result.test)
+          .to.haveOwnProperty("type")
+          .that.equals(Map);
+        expect(this.result.test)
+          .to.haveOwnProperty("of")
+          .that.equals(String);
+      });
+
+      it("should not have an _id", () => {
+        expect(this.result).to.not.haveOwnProperty("_id");
+      });
+    });
+
+    describe("when property is a class", () => {
+      class Children { }
+
+      describe("when property is a subdocument", () => {
+        before(() => {
+          this.propertyMetadata = {
+            type: Children,
+            required: true,
+            isClass: true,
+            store: {
+              get: Sinon.stub().returns(undefined)
+            }
+          };
+
+          this.innerPropertyMetadata = {
+            type: String,
+            required: false,
+            isClass: false,
+            isArray: true,
+            store: {
+              get: Sinon.stub().returns(undefined)
+            }
+          };
+
+          this.getPropertiesStub = Sinon.stub(PropertyRegistry, "getProperties")
+            .onFirstCall()
+            .returns(new Map<string, any>([["test", this.propertyMetadata], ["_id", {}]]))
+            .onSecondCall()
+            .returns(new Map<string, any>([["prop", this.innerPropertyMetadata], ["_id", {}]]));
+
+          this.getSchemaDefinitionStub = Sinon.stub(JsonSchemesRegistry, "getSchemaDefinition")
+            .onFirstCall()
+            .returns({
+              properties: {
+                test: {}
+              }
+            });
+
+          this.result = buildMongooseSchema(Test);
+        });
+
+        after(() => {
+          this.getPropertiesStub.restore();
+          this.getSchemaDefinitionStub.restore();
+          this.propertyMetadata.store.get.restore();
+          this.innerPropertyMetadata.store.get.restore();
+        });
+
+        it("should call getProperties and returns a list of properties", () => {
+          this.getPropertiesStub.should.have.been.calledWithExactly(Test);
+          this.getPropertiesStub.should.not.have.been.calledWithExactly(Children);
+        });
+
+        it("should call store.get", () => {
+          this.propertyMetadata.store.get.should.have.been.calledWithExactly(MONGOOSE_SCHEMA);
+        });
+
+        it("should return a schema with property test", () => {
+          expect(this.result)
+            .to.haveOwnProperty("test")
+            .that.is.an("object");
+          expect(this.result.test)
+            .to.haveOwnProperty("required")
+            .that.is.a("function");
+          expect(this.result.test)
+            .to.haveOwnProperty("prop")
+            .that.deep.equals([
+              {
+                required: false,
+                type: String
+              }
+            ]);
+        });
+
+        it("should not have an _id", () => {
+          expect(this.result).to.not.haveOwnProperty("_id");
+        });
+      });
+
+      describe("when property is a reference class", () => {
+        before(() => {
+          this.propertyMetadata = {
+            type: Children,
+            required: true,
+            isClass: true,
+            store: {
+              get: Sinon.stub().returns({
+                type: Schema.Types.ObjectId,
+                ref: "Children"
+              })
+            }
+          };
+
+          this.innerPropertyMetadata = {
+            type: String,
+            required: false,
+            isClass: false,
+            isArray: true,
+            store: {
+              get: Sinon.stub().returns(undefined)
+            }
+          };
+
+          this.getPropertiesStub = Sinon.stub(PropertyRegistry, "getProperties")
+            .onFirstCall()
+            .returns(new Map<string, any>([["test", this.propertyMetadata], ["_id", {}]]))
+            .onSecondCall()
+            .returns(new Map<string, any>([["prop", this.innerPropertyMetadata], ["_id", {}]]));
+
+          this.getSchemaDefinitionStub = Sinon.stub(JsonSchemesRegistry, "getSchemaDefinition")
+            .onFirstCall()
+            .returns({
+              properties: {
+                test: {}
+              }
+            });
+
+          this.result = buildMongooseSchema(Test);
+        });
+
+        after(() => {
+          this.getPropertiesStub.restore();
+          this.getSchemaDefinitionStub.restore();
+          this.propertyMetadata.store.get.restore();
+          this.innerPropertyMetadata.store.get.restore();
+        });
+
+        it("should call getProperties and returns a list of properties", () => {
+          this.getPropertiesStub.should.have.been.calledWithExactly(Test);
+        });
+
+        it("should call store.get", () => {
+          this.propertyMetadata.store.get.should.have.been.calledWithExactly(MONGOOSE_SCHEMA);
+        });
+
+        it("should return a schema with property test", () => {
+          expect(this.result)
+            .to.haveOwnProperty("test")
+            .that.is.an("object");
+          expect(this.result.test)
+            .to.haveOwnProperty("type")
+            .that.equals(Schema.Types.ObjectId);
+          expect(this.result.test)
+            .to.haveOwnProperty("ref")
+            .that.equals("Children");
+          expect(this.result.test)
+            .to.haveOwnProperty("required")
+            .that.is.a("function");
+          expect(this.result.test).to;
+        });
+
+        it("should not have an _id", () => {
+          expect(this.result).to.not.haveOwnProperty("_id");
+        });
+      });
+
+      describe("when property is a virtual reference", () => {
+        before(() => {
+          this.propertyMetadata = {
+            type: Children,
+            isClass: false,
+            isArray: true,
+            store: {
+              get: Sinon.stub().returns({
+                ref: "Children",
+                localField: "_id",
+                foreignField: "tester",
+                justOne: false
+              })
+            }
+          };
+
+          this.reversePropertyMetadata = {
+            type: Test,
+            required: true,
+            isClass: true,
+            store: {
+              get: Sinon.stub().returns({
+                type: Schema.Types.ObjectId,
+                ref: "Test"
+              })
+            }
+          };
+
+          this.innerPropertyMetadata = {
+            type: String,
+            required: false,
+            isClass: false,
+            isArray: true,
+            store: {
+              get: Sinon.stub().returns(undefined)
+            }
+          };
+
+          this.getPropertiesStub = Sinon.stub(PropertyRegistry, "getProperties")
+            .onFirstCall()
+            .returns(new Map<string, any>([["test", this.propertyMetadata], ["_id", {}]]))
+            .onSecondCall()
+            .returns(new Map<string, any>([["tester", this.reversePropertyMetadata], ["prop", this.innerPropertyMetadata], ["_id", {}]]));
+
+          this.getSchemaDefinitionStub = Sinon.stub(JsonSchemesRegistry, "getSchemaDefinition")
+            .onFirstCall()
+            .returns({
+              properties: {
+                test: {}
+              }
+            });
+
+          this.result = buildMongooseSchema(Test);
+        });
+
+        after(() => {
+          this.getPropertiesStub.restore();
+          this.getSchemaDefinitionStub.restore();
+          this.propertyMetadata.store.get.restore();
+          this.reversePropertyMetadata.store.get.restore();
+          this.innerPropertyMetadata.store.get.restore();
+        });
+
+        it("should call getProperties and returns a list of properties", () => {
+          this.getPropertiesStub.should.have.been.calledWithExactly(Test);
+        });
+
+        it("should call store.get", () => {
+          this.propertyMetadata.store.get.should.have.been.calledWithExactly(MONGOOSE_SCHEMA);
+        });
+
+        it("should return a schema with property test", () => {
+          expect(this.result).to.not.haveOwnProperty("test");
+          expect(this.result.virtuals).to.haveOwnProperty("test");
+        });
+
+        it("should not have an _id", () => {
+          expect(this.result).to.not.haveOwnProperty("_id");
+        });
       });
     });
   });

--- a/packages/mongoose/test/utils/buildMongooseSchema.spec.ts
+++ b/packages/mongoose/test/utils/buildMongooseSchema.spec.ts
@@ -374,7 +374,7 @@ describe("buildMongooseSchema", () => {
           expect(this.result.test)
             .to.haveOwnProperty("required")
             .that.is.a("function");
-          expect(this.result.test).to;
+          expect(this.result.test).to.not.haveOwnProperty("prop");
         });
 
         it("should not have an _id", () => {

--- a/packages/mongoose/test/utils/createModel.spec.ts
+++ b/packages/mongoose/test/utils/createModel.spec.ts
@@ -7,27 +7,13 @@ import {createModel} from "../../src/utils";
 
 describe("createModel()", () => {
   describe("when the model name is given", () => {
-    class Test {
-    }
+    class Test {}
 
     before(() => {
-      this.schema = {
-        loadClass: Sinon.stub()
-      };
-
+      this.schema = {};
       this.modelStub = Sinon.stub(mongoose, "model");
 
-      this.converterStub = {
-        serializeClass: Sinon.stub()
-      };
-
       createModel(Test, this.schema, "name", "collection", true);
-
-      this.instance = new Test();
-      this.instance.serialize({
-        checkRequiredValue: "checkRequiredValue",
-        ignoreCallback: "ignoreCallback"
-      }, this.converterStub);
     });
 
     after(() => {
@@ -38,44 +24,20 @@ describe("createModel()", () => {
       expect(Store.from(Test).get(MONGOOSE_MODEL_NAME)).to.equals("name");
     });
 
-    it("should call loadClass", () => {
-      this.schema.loadClass.should.have.been.calledWithExactly(Test);
-    });
-
     it("should call mongoose.model", () => {
       this.modelStub.should.have.been.calledWithExactly("name", this.schema, "collection", true);
     });
-
-    it("should converter.serializeClass", () => {
-      this.converterStub.serializeClass.should.have.been.calledWithExactly(this.instance, {
-        type: Test,
-        checkRequiredValue: "checkRequiredValue",
-        ignoreCallback: "ignoreCallback"
-      });
-    });
   });
+
   describe("when the model name is not given", () => {
     class Test {
     }
 
     before(() => {
-      this.schema = {
-        loadClass: Sinon.stub()
-      };
-
+      this.schema = {}
       this.modelStub = Sinon.stub(mongoose, "model");
 
-      this.converterStub = {
-        serializeClass: Sinon.stub()
-      };
-
       createModel(Test, this.schema);
-
-      this.instance = new Test();
-      this.instance.serialize({
-        checkRequiredValue: "checkRequiredValue",
-        ignoreCallback: "ignoreCallback"
-      }, this.converterStub);
     });
 
     after(() => {
@@ -86,20 +48,8 @@ describe("createModel()", () => {
       expect(Store.from(Test).get(MONGOOSE_MODEL_NAME)).to.equals("Test");
     });
 
-    it("should call loadClass", () => {
-      this.schema.loadClass.should.have.been.calledWithExactly(Test);
-    });
-
     it("should call mongoose.model", () => {
       this.modelStub.should.have.been.calledWithExactly("Test", this.schema, undefined, undefined);
-    });
-
-    it("should converter.serializeClass", () => {
-      this.converterStub.serializeClass.should.have.been.calledWithExactly(this.instance, {
-        type: Test,
-        checkRequiredValue: "checkRequiredValue",
-        ignoreCallback: "ignoreCallback"
-      });
     });
   });
 });

--- a/packages/mongoose/test/utils/createSchema.spec.ts
+++ b/packages/mongoose/test/utils/createSchema.spec.ts
@@ -8,11 +8,32 @@ describe("createSchema()", () => {
   }
 
   before(() => {
-    this.buildMongooseSchemaStub = Sinon.stub(mod, "buildMongooseSchema").returns({definition: "definition"} as any);
+    this.buildMongooseSchemaStub = Sinon.stub(mod, "buildMongooseSchema").returns({
+      schema: {
+        definition: "definition"
+      },
+      virtuals: new Map([["virtual", {}]])
+    } as any);
 
-    this.schemaStub = Sinon.stub(mongoose, "Schema");
+    this.virtualStub = Sinon.stub();
+    this.loadClassStub = Sinon.stub();
+
+    this.schemaStub = Sinon.stub(mongoose, "Schema").returns({
+      virtual: this.virtualStub,
+      loadClass: this.loadClassStub
+    });
+
+    this.converterStub = {
+      serializeClass: Sinon.stub()
+    };
 
     createSchema(Test, {options: "options"} as any);
+
+    this.instance = new Test();
+    this.instance.serialize({
+      checkRequiredValue: "checkRequiredValue",
+      ignoreCallback: "ignoreCallback"
+    }, this.converterStub);
   });
 
   after(() => {
@@ -26,5 +47,21 @@ describe("createSchema()", () => {
 
   it("should create a schema instance", () => {
     this.schemaStub.should.have.been.calledWithExactly({definition: "definition"}, {options: "options"});
+  });
+
+  it("should add virtuals", () => {
+    this.virtualStub.should.have.been.calledWithExactly("virtual", {});
+  });
+
+  it("should load class", () => {
+    this.loadClassStub.should.have.been.calledWithExactly(Test);
+  });
+
+  it("should converter.serializeClass", () => {
+    this.converterStub.serializeClass.should.have.been.calledWithExactly(this.instance, {
+      type: Test,
+      checkRequiredValue: "checkRequiredValue",
+      ignoreCallback: "ignoreCallback"
+    });
   });
 });

--- a/packages/mongoose/test/utils/createSchema.spec.ts
+++ b/packages/mongoose/test/utils/createSchema.spec.ts
@@ -1,19 +1,22 @@
 import * as mongoose from "mongoose";
 import * as Sinon from "sinon";
 import {createSchema} from "../../src/utils";
-import * as mod from "../../src/utils/buildMongooseSchema";
+import * as modBuild from "../../src/utils/buildMongooseSchema";
+import * as modApply from "../../src/utils/schemaOptions";
 
 describe("createSchema()", () => {
   class Test {
   }
 
   before(() => {
-    this.buildMongooseSchemaStub = Sinon.stub(mod, "buildMongooseSchema").returns({
+    this.buildMongooseSchemaStub = Sinon.stub(modBuild, "buildMongooseSchema").returns({
       schema: {
         definition: "definition"
       },
       virtuals: new Map([["virtual", {}]])
     } as any);
+
+    this.applyStub = Sinon.stub(modApply, "applySchemaOptions");
 
     this.virtualStub = Sinon.stub();
     this.loadClassStub = Sinon.stub();
@@ -27,7 +30,7 @@ describe("createSchema()", () => {
       serializeClass: Sinon.stub()
     };
 
-    createSchema(Test, {options: "options"} as any);
+    createSchema(Test, {schemaOptions: {options: "options"}} as any);
 
     this.instance = new Test();
     this.instance.serialize({
@@ -38,6 +41,7 @@ describe("createSchema()", () => {
 
   after(() => {
     this.buildMongooseSchemaStub.restore();
+    this.applyStub.restore();
     this.schemaStub.restore();
   });
 
@@ -47,6 +51,10 @@ describe("createSchema()", () => {
 
   it("should create a schema instance", () => {
     this.schemaStub.should.have.been.calledWithExactly({definition: "definition"}, {options: "options"});
+  });
+
+  it("should call applySchemaOptions", () => {
+    this.applyStub.should.have.been.calledWithExactly(Test, {schemaOptions: {options: "options"}})
   });
 
   it("should add virtuals", () => {


### PR DESCRIPTION
## Informations
- Chore: Added tests for `buildMongooseSchema` | No
- Fix: Rewrote `createModel` and `createSchema` to conform to mongoose definitions for model and schema | No
- Feature: Added a `@Schema` decorator for specifying mongoose schema | No
- Feature: Added support for mongoose virtual reference | No
- Feature: Added support for mongoose map | No, but require mongoose >= 5.1.0

## Description
Better conforming to mongoose definitions of schema and model and supporting newer functionalities.
[Issue #482](https://github.com/Romakita/ts-express-decorators/issues/482)

## Todos
- [x] Tests
- [ ] Coverage: specific exception case are not covered. Only general non throwing way is.
- [ ] Example: In JSDoc, there are simple examples where useful.
- [ ] Documentation
