### PR TITLE
fix(common): allow configuration null value

### DIFF
--- a/packages/common/src/config/services/ServerSettingsService.ts
+++ b/packages/common/src/config/services/ServerSettingsService.ts
@@ -446,7 +446,7 @@ export class ServerSettingsService implements IServerSettings, IDISettings {
    * @returns {any}
    */
   resolve(value: any) {
-    if (typeof value === "object") {
+    if (typeof value === "object" && value !== null) {
       Object.keys(value).forEach((k: string, i: number, m: any) => {
         value[k] = this.resolve(value[k]);
       });

--- a/packages/common/test/config/services/ServerSettingsService.spec.ts
+++ b/packages/common/test/config/services/ServerSettingsService.spec.ts
@@ -150,6 +150,13 @@ describe("ServerSettingsService", () => {
       });
 
       it("should replace rootDir", () => {
+        expect(this.settings.resolve({other: null, resolve: "${rootDir}"})).to.deep.eq({
+          other: null,
+          resolve: process.cwd()
+        });
+      });
+
+      it("should replace rootDir", () => {
         expect(this.settings.resolve({other: 808, resolve: "${rootDir}"})).to.deep.eq({
           other: 808,
           resolve: process.cwd()


### PR DESCRIPTION
## Informations

- Fix: allow configuration null value

****

## Description
Type of null is object but must not be used as an object in settings. This condition allow use of null value in settings.

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
