### PR TITLE
Custom Server & Subscriptions (GraphQL)

### DIFF
--- a/packages/graphql/src/interfaces/IGraphQLSettings.ts
+++ b/packages/graphql/src/interfaces/IGraphQLSettings.ts
@@ -14,7 +14,7 @@ export interface IGraphQLSettings {
   // type-graphql
   // See options descriptions on https://19majkel94.github.io/type-graphql/
   buildSchemaOptions?: BuildSchemaOptions;
-  
+
   installSubscriptionHandlers?: boolean;
   server?: (config: Config) => ApolloServer;
 }

--- a/packages/graphql/src/interfaces/IGraphQLSettings.ts
+++ b/packages/graphql/src/interfaces/IGraphQLSettings.ts
@@ -1,4 +1,4 @@
-import {Config, ServerRegistration} from "apollo-server-express";
+import {Config, ServerRegistration, ApolloServer} from "apollo-server-express";
 import {BuildSchemaOptions} from "type-graphql";
 
 export interface IGraphQLSettings {
@@ -14,4 +14,7 @@ export interface IGraphQLSettings {
   // type-graphql
   // See options descriptions on https://19majkel94.github.io/type-graphql/
   buildSchemaOptions?: BuildSchemaOptions;
+  
+  installSubscriptionHandlers?: boolean;
+  server?: (config: Config) => ApolloServer;
 }

--- a/packages/graphql/src/services/GraphQLService.ts
+++ b/packages/graphql/src/services/GraphQLService.ts
@@ -16,7 +16,7 @@ export class GraphQLService {
   private _instances: Map<string, ApolloServer> = new Map();
 
   constructor(
-    @ExpressApplication private expressApp: ExpressApplication, 
+    @ExpressApplication private expressApp: ExpressApplication,
     @Inject(HttpServer) private httpServer: HttpServer,
     private injectorService: InjectorService
   ) {}
@@ -26,7 +26,15 @@ export class GraphQLService {
    * @returns {Promise<"mongoose".Connection>}
    */
   async createServer(id: string, settings: IGraphQLSettings): Promise<any> {
-    const {path, server: customServer, installSubscriptionHandlers, resolvers = [], serverConfig = {}, serverRegistration = {}, buildSchemaOptions = {} as any} = settings;
+    const {
+      path,
+      server: customServer,
+      installSubscriptionHandlers,
+      resolvers = [],
+      serverConfig = {},
+      serverRegistration = {},
+      buildSchemaOptions = {} as any
+    } = settings;
     if (this.has(id)) {
       return await this.get(id)!;
     }
@@ -45,9 +53,7 @@ export class GraphQLService {
         schema
       };
 
-      const server = customServer ? 
-            customServer(defaultServerConfig) : 
-            new ApolloServer(defaultServerConfig);
+      const server = customServer ? customServer(defaultServerConfig) : new ApolloServer(defaultServerConfig);
 
       server.applyMiddleware({path, ...serverRegistration, app: this.expressApp});
 


### PR DESCRIPTION
## Informations

I added a few more settings:

1. `server` allows to set a custom server via callback (I use a customized server in my project and it would be very useful)
2. `installSubscriptionHandlers` allows to bind httpServer to Apollo Server (it's needed for subscriptions: https://www.apollographql.com/docs/apollo-server/features/subscriptions.html#middleware)

Type | Breaking change
---|---
Feature | No

****

## Usage example

```typescript
import {ServerLoader, ServerSettings} from "@tsed/common";
import {IGraphQLSettings} from "@tsed/graphql"; 

@ServerSettings({
   graphql: {
    'server1': {
      resolvers:[],
      installSubscriptionHandlers: true,
      server: config => new CustomApolloServer(config)
    }
  } as IGraphQLSettings
})
export class Server extends ServerLoader {

}
```

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation